### PR TITLE
Port: Add proto container for s2dk Certificate object.

### DIFF
--- a/jvm/common/src/main/proto/squareup/cash/s2dk/api/alpha/public.proto
+++ b/jvm/common/src/main/proto/squareup/cash/s2dk/api/alpha/public.proto
@@ -12,3 +12,20 @@ message MobileCertificateRequest {
 message MobileCertificateResponse {
   repeated bytes certificates = 1;
 }
+
+/**
+ * The certificate object handled by s2dk. This proto is used as a serialization/deserialization
+ * mechanism for an otherwise opaque object whose representation is internal to the library only.
+ * The purpose of this message is to bind a public key with a set of verified attributes about the
+ * entity which controls the private key corresponding to the given public key.
+ */
+message Certificate {
+  // Version describing the current format of the underlying bytes of the certificate. This tells
+  // the s2dk library, and only the s2dk library, how to interpret the certificate bytes.
+  // Required.
+  optional uint32 version = 1;
+
+  // The current representation is fundamentally an x.509 certificate as defined in
+  // https://datatracker.ietf.org/doc/html/rfc5280, with most of the fields and features ignored.
+  optional bytes certificate = 2;
+}


### PR DESCRIPTION
Add a protobuf representation of one of the key objects exposed by the s2dk library. This object will be treated as an opaque object for library clients but will provide the foundation for key usage within the s2dk library. In particular the certificate will be used to provide cryptographic keys for encryption and verification in most library operations.