### PR TITLE
Port: "Add TinkContentSigner to s2dk internal package."

### DIFF
--- a/jvm/common/build.gradle.kts
+++ b/jvm/common/build.gradle.kts
@@ -57,6 +57,17 @@ apply(plugin = "kotlin")
 
 val protosSrc = "src/main/proto/"
 
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation("org.bouncycastle:bcprov-jdk15to18:1.70")
+  implementation("org.bouncycastle:bcpkix-jdk15to18:1.70")
+  implementation("com.google.crypto.tink:tink:1.6.0")
+  implementation("org.junit.jupiter:junit-jupiter:5.7.0")
+}
+
 wire {
   protoLibrary = true
   sourcePath {

--- a/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/TinkContentSigner.kt
+++ b/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/TinkContentSigner.kt
@@ -1,0 +1,42 @@
+package app.cash.security_sdk.internal
+
+import com.google.crypto.tink.PublicKeySign
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.bouncycastle.operator.ContentSigner
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+/**
+ * Internal s2dk class to enable bouncycastle to delegate signing to Tink primitives rather than
+ * requiring Tink key users to extract the material. This should enable s2dk Clients to supply Tink
+ * keys directly without needing to reason about their internals.
+ */
+internal class TinkContentSigner(
+  private val publicKeySign: PublicKeySign,
+  private val outputStream: ByteArrayOutputStream = ByteArrayOutputStream()
+) : ContentSigner {
+  val tinkAlgorithmIdentifier: AlgorithmIdentifier
+    //TODO(dcashman): Add support for different algorithms.
+    get() = AlgorithmIdentifier(ASN1ObjectIdentifier(ED25519_OID))
+
+  override fun getAlgorithmIdentifier(): AlgorithmIdentifier {
+    return tinkAlgorithmIdentifier
+  }
+
+  override fun getOutputStream(): OutputStream {
+    return outputStream
+  }
+
+  override fun getSignature(): ByteArray {
+    val signedBytes = publicKeySign.sign(outputStream.toByteArray())
+    outputStream.reset()
+    return signedBytes
+  }
+
+  internal companion object {
+    // Defined in https://www.rfc-editor.org/rfc/rfc8420.html
+    // Registry http://oid-info.com/cgi-bin/display?oid=1.3.101.112
+    internal const val ED25519_OID = "1.3.101.112"
+  }
+}

--- a/jvm/common/src/test/kotlin/app/cash/security_sdk/internal/TinkContentSignerTest.kt
+++ b/jvm/common/src/test/kotlin/app/cash/security_sdk/internal/TinkContentSignerTest.kt
@@ -1,0 +1,49 @@
+package app.cash.security_sdk.internal
+
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.PublicKeySign
+import com.google.crypto.tink.PublicKeyVerify
+import com.google.crypto.tink.signature.SignatureConfig
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+internal class TinkContentSignerTest {
+  private val data = byteArrayOf(0x00, 0x01, 0x02, 0x03)
+  private lateinit var ed25519PublicKeySign: PublicKeySign
+  private lateinit var ed25519PublicKeyVerify: PublicKeyVerify
+
+  @BeforeEach
+  fun setUp() {
+    SignatureConfig.register()
+    val ed25519PrivateKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("ED25519"))
+    ed25519PublicKeySign = ed25519PrivateKeyHandle.getPrimitive(PublicKeySign::class.java)
+    val ed25519PublicKeyHandle = ed25519PrivateKeyHandle.publicKeysetHandle
+    ed25519PublicKeyVerify = ed25519PublicKeyHandle.getPrimitive(PublicKeyVerify::class.java)
+  }
+
+  @Test
+  fun `test ed25519 signature algorithm returns correct OID`() {
+    val tinkContentSigner = TinkContentSigner(ed25519PublicKeySign)
+    val ed25519Oid = AlgorithmIdentifier(ASN1ObjectIdentifier(TinkContentSigner.ED25519_OID))
+    assertEquals(ed25519Oid, tinkContentSigner.getAlgorithmIdentifier())
+  }
+
+  @Test
+  fun `test sign matches tink signature`() {
+    val tinkContentSigner = TinkContentSigner(ed25519PublicKeySign)
+    val outputStream = tinkContentSigner.getOutputStream()
+    outputStream.write(data)
+    val signedOutput = tinkContentSigner.getSignature()
+
+    assertArrayEquals(signedOutput, ed25519PublicKeySign.sign(data))
+
+    // Verify does not return anything, but throws exception if signature does not verify correctly.
+    assertDoesNotThrow { ed25519PublicKeyVerify.verify(signedOutput, data) }
+  }
+}


### PR DESCRIPTION
* Add TinkContentSigner to s2dk internal package.

s2dk currently offers certificates as opaque wrappers around x.509 certificates, and uses bouncycastle to manipulate them.  Cash uses the Tink cryptography library, though, for its key management and associated cryptographic operations. s2dk will also likely provide APIs built on top of Tink. Create a TinkContentSigner to enable bouncycastle to work with Tink directly rather than forcing clients to extract keys into a different format prior to calling s2dk.

Internal slack thread:
https://cash.slack.com/archives/C046H8PR3U4/p1668193785853249

JIRA=https://ccp-cashapp.atlassian.net/browse/PRODSQUAD-254