### PR TITLE
Port: "Add TinkContentVerifier to s2dk internal utilities."

### DIFF
--- a/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/TinkContentVerifier.kt
+++ b/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/TinkContentVerifier.kt
@@ -1,0 +1,44 @@
+package app.cash.security_sdk.internal
+
+import app.cash.security_sdk.internal.TinkContentSigner.Companion.ED25519_OID
+import com.google.crypto.tink.PublicKeyVerify
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.bouncycastle.operator.ContentVerifier
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.security.GeneralSecurityException
+
+/**
+ * Internal s2dk class to enable bouncycastle to delegate verifying to Tink primitives rather than
+ * requiring Tink key users to extract the material. This should enable s2dk Clients to supply Tink
+ * keys directly without needing to reason about their internals.
+ */
+internal class TinkContentVerifier(
+  private val publicKeyVerify: PublicKeyVerify,
+  private val outputStream: ByteArrayOutputStream = ByteArrayOutputStream()
+) : ContentVerifier {
+  private val tinkAlgorithmIdentifier: AlgorithmIdentifier
+    //TODO(dcashman): Add support for different algorithms.
+    get() = AlgorithmIdentifier(ASN1ObjectIdentifier(ED25519_OID))
+
+  override fun getAlgorithmIdentifier(): AlgorithmIdentifier {
+    return tinkAlgorithmIdentifier
+  }
+
+  override fun getOutputStream(): OutputStream {
+    return outputStream
+  }
+
+  override fun verify(expected: ByteArray): Boolean {
+    return try {
+      publicKeyVerify.verify(expected, outputStream.toByteArray())
+      true
+    } catch (e: GeneralSecurityException) {
+      // Signature did not verify.
+      false;
+    } finally {
+      outputStream.reset()
+    }
+  }
+}

--- a/jvm/common/src/test/kotlin/app/cash/security_sdk/internal/TinkContentVerifierTest.kt
+++ b/jvm/common/src/test/kotlin/app/cash/security_sdk/internal/TinkContentVerifierTest.kt
@@ -1,0 +1,44 @@
+package app.cash.security_sdk.internal
+
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.PublicKeySign
+import com.google.crypto.tink.PublicKeyVerify
+import com.google.crypto.tink.signature.SignatureConfig
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class TinkContentVerifierTest {
+  private val data = byteArrayOf(0x00, 0x01, 0x02, 0x03)
+  private lateinit var ed25519PublicKeySign: PublicKeySign
+  private lateinit var ed25519PublicKeyVerify: PublicKeyVerify
+
+  @BeforeEach
+  fun setUp() {
+    SignatureConfig.register()
+    val ed25519PrivateKeyHandle = KeysetHandle.generateNew(KeyTemplates.get("ED25519"))
+    ed25519PublicKeySign = ed25519PrivateKeyHandle.getPrimitive(PublicKeySign::class.java)
+    val ed25519PublicKeyHandle = ed25519PrivateKeyHandle.publicKeysetHandle
+    ed25519PublicKeyVerify = ed25519PublicKeyHandle.getPrimitive(PublicKeyVerify::class.java)
+  }
+
+  @Test
+  fun `test ed25519 signature algorithm returns correct OID`() {
+    val tinkContentVerifier = TinkContentVerifier(ed25519PublicKeyVerify)
+    val ed25519Oid = AlgorithmIdentifier(ASN1ObjectIdentifier(TinkContentSigner.ED25519_OID))
+    assertEquals(ed25519Oid, tinkContentVerifier.algorithmIdentifier)
+  }
+
+  @Test
+  fun `test verify passes for legitimate tink signature`() {
+    val tinkContentVerifier = TinkContentVerifier(ed25519PublicKeyVerify)
+    val outputStream = tinkContentVerifier.outputStream
+    outputStream.write(data)
+
+    assertTrue(tinkContentVerifier.verify(ed25519PublicKeySign.sign(data)))
+  }
+}


### PR DESCRIPTION
TinkContentVerifier is the complement to TinkContentSigner, which allows bouncy castle to verify certificates that were signed by teh TinkContentSigner.  This will be provided by ContentVerifierProvider and passed to the certificate's isSignatureValid() method.