### PR TITLE
Port: "Root cert gen"

### DIFF
--- a/jvm/common/src/main/kotlin/app/cash/security_sdk/CertificateUtil.kt
+++ b/jvm/common/src/main/kotlin/app/cash/security_sdk/CertificateUtil.kt
@@ -1,8 +1,18 @@
 package app.cash.security_sdk
 
+import app.cash.security_sdk.internal.TinkContentSigner
+import app.cash.security_sdk.internal.toSubjectPublicKeyInfo
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.PublicKeySign
 import com.squareup.protos.cash.s2dk.api.alpha.MobileCertificateRequest
 import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.X509v3CertificateBuilder
 import java.math.BigInteger
+import java.time.Instant
+import java.time.Period
+import java.util.Date
 
 /**
  * Server S2DK utility class for certificate enrollment.
@@ -32,4 +42,35 @@ object CertificateUtil {
     signingKeySecret: BigInteger,
     certificateRequest: CertificateRequest
   ): SigningCert = SigningCert(ByteString.EMPTY)
+
+  /**
+   * Creates a self-signed certificate with the provided key and name.
+   *
+   * @param entityName the name with which we'll associate the public key.
+   * @param validityPeriod the length of time for which this certificate should be accepted after
+   * issuance.
+   * @param tinkSigningKeyset the Tink key used to sign the certificate.
+   */
+  fun createRootSigningCertificate(
+    entityName: String,
+    validityPeriod: Period,
+    tinkSigningKeyset: KeysetHandle,
+  ): SigningCert {
+    // s2dk Certificates are just wrappers around X.509 certificates. Create one with the
+    // given name.
+    val subjectName = X500Name("CN=$entityName")
+    val creationTime = Instant.now()
+    val cert = X509v3CertificateBuilder(
+      subjectName,
+      BigInteger.ONE,
+      Date.from(creationTime),
+      Date.from(creationTime.plus(validityPeriod)),
+      subjectName,
+      tinkSigningKeyset.toSubjectPublicKeyInfo()
+    )
+    val signedCert =
+      cert.build(TinkContentSigner(tinkSigningKeyset.getPrimitive(PublicKeySign::class.java)))
+
+    return SigningCert(signedCert.encoded.toByteString(0, signedCert.encoded.size))
+  }
 }

--- a/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/S2DKContentVerifierProvider.kt
+++ b/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/S2DKContentVerifierProvider.kt
@@ -1,0 +1,47 @@
+package app.cash.security_sdk.internal
+
+import app.cash.security_sdk.SigningCert
+import com.google.crypto.tink.BinaryKeysetReader
+import com.google.crypto.tink.CleartextKeysetHandle
+import com.google.crypto.tink.PublicKeyVerify
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.operator.ContentVerifier
+import org.bouncycastle.operator.ContentVerifierProvider
+
+/**
+ * Internal s2dk class to enable bouncycastle to delegate signing to Tink primitives rather than
+ * requiring Tink key users to extract the material. This should enable s2dk Clients to supply Tink
+ * keys directly without needing to reason about their internals.
+ */
+internal class S2DKContentVerifierProvider(
+  private val signingCert: SigningCert
+) : ContentVerifierProvider {
+  private val x509Certificate = X509CertificateHolder(signingCert.certificate.toByteArray())
+
+  override fun get(algorithmIdentifer: AlgorithmIdentifier): ContentVerifier {
+    val subjectPublicKeyInfo = x509Certificate.subjectPublicKeyInfo
+
+    // TODO(dcashman): this is effectively ignored at the moment, but we should ensure that the
+    // the algorithm passed-in matches our expected Tink algorithm ID.
+    if (!algorithmIdentifer.equals(AlgorithmIdentifier(ASN1ObjectIdentifier(TinkContentSigner.ED25519_OID)))
+      || !algorithmIdentifer.equals(subjectPublicKeyInfo.algorithm)) {
+      throw UnsupportedOperationException("Unknown/unsupported AlgorithmId provided to obtain S2DK ContentVerifier")
+    }
+
+    // Create PublicKeyVerify instance for verifier.
+    return TinkContentVerifier(
+      CleartextKeysetHandle.read(BinaryKeysetReader.withBytes(subjectPublicKeyInfo.publicKeyData.bytes))
+        .getPrimitive(PublicKeyVerify::class.java)
+    )
+  }
+
+  override fun getAssociatedCertificate(): X509CertificateHolder {
+    return x509Certificate
+  }
+
+  override fun hasAssociatedCertificate(): Boolean {
+    return true
+  }
+}

--- a/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/TinkContentVerifier.kt
+++ b/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/TinkContentVerifier.kt
@@ -36,9 +36,10 @@ internal class TinkContentVerifier(
       true
     } catch (e: GeneralSecurityException) {
       // Signature did not verify.
-      false;
+      false
     } finally {
       outputStream.reset()
     }
   }
 }
+

--- a/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/TinkUtil.kt
+++ b/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/TinkUtil.kt
@@ -1,0 +1,23 @@
+package app.cash.security_sdk.internal
+
+import com.google.crypto.tink.BinaryKeysetWriter
+import com.google.crypto.tink.CleartextKeysetHandle
+import com.google.crypto.tink.KeysetHandle
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import java.io.ByteArrayOutputStream
+
+fun KeysetHandle.toSubjectPublicKeyInfo(): SubjectPublicKeyInfo {
+  val outputStream = ByteArrayOutputStream()
+  CleartextKeysetHandle.write(
+    // Ensure we only write the public component of our key!
+    publicKeysetHandle,
+    BinaryKeysetWriter.withOutputStream(outputStream)
+  )
+  return SubjectPublicKeyInfo(
+    // TODO(dcashman): Define a custom OID based on tink primitives.
+    AlgorithmIdentifier(ASN1ObjectIdentifier(TinkContentSigner.ED25519_OID)),
+    outputStream.toByteArray()
+  )
+}

--- a/jvm/common/src/test/kotlin/app/cash/security_sdk/CertificateUtilTest.kt
+++ b/jvm/common/src/test/kotlin/app/cash/security_sdk/CertificateUtilTest.kt
@@ -1,0 +1,81 @@
+package app.cash.security_sdk
+
+import app.cash.security_sdk.internal.S2DKContentVerifierProvider
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.signature.SignatureConfig
+import org.bouncycastle.cert.X509CertificateHolder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Period
+
+internal class CertificateUtilTest {
+  private lateinit var ed25519PrivateKeysetHandle: KeysetHandle
+
+  @BeforeEach
+  fun setUp() {
+    SignatureConfig.register()
+    ed25519PrivateKeysetHandle = KeysetHandle.generateNew(KeyTemplates.get("ED25519"))
+  }
+
+  @Test
+  fun `test createRootSigningCertificate validity period`() {
+    val cert = CertificateUtil.createRootSigningCertificate(
+      "entity", Period.ofDays(1), ed25519PrivateKeysetHandle
+    )
+
+    val certHolder = X509CertificateHolder(cert.certificate.toByteArray())
+    val duration =
+      Duration.ofMillis(
+        certHolder.notAfter.toInstant().minusMillis(certHolder.notBefore.toInstant().toEpochMilli())
+          .toEpochMilli()
+      )
+    assertEquals(1, duration.toDays())
+  }
+
+  @Test
+  fun `test createRootSigningCertificate certificate entity`() {
+    val cert = CertificateUtil.createRootSigningCertificate(
+      "entity", Period.ofDays(1), ed25519PrivateKeysetHandle
+    )
+
+    // Extract cert and then entity value.
+    val certHolder = X509CertificateHolder(cert.certificate.toByteArray())
+    assertEquals("CN=entity", certHolder.issuer.toString())
+  }
+
+  @Test
+  fun `test createRootSigningCertificate certificate issuer`() {
+    val cert = CertificateUtil.createRootSigningCertificate(
+      "entity", Period.ofDays(1), ed25519PrivateKeysetHandle
+    )
+
+    // Extract cert and then entity value.
+    val certHolder = X509CertificateHolder(cert.certificate.toByteArray())
+    assertEquals("CN=entity", certHolder.subject.toString())
+  }
+
+  @Test
+  fun `test createRootSigningCertificate signing`() {
+    // Create root signing cert using our keyset.  Root cert is self-signed.
+    val signingCert = CertificateUtil.createRootSigningCertificate(
+      "entity", Period.ofDays(1), ed25519PrivateKeysetHandle
+    )
+
+    // Extract the x.509 certificate from our object.
+    val certHolder = X509CertificateHolder(signingCert.certificate.toByteArray())
+
+    // Self-signed cert should verify when presented with itself.
+    assertTrue(certHolder.isSignatureValid(S2DKContentVerifierProvider(signingCert)))
+
+    // Different key should not verify
+    val otherCert = CertificateUtil.createRootSigningCertificate(
+      "entity", Period.ofDays(1), KeysetHandle.generateNew(KeyTemplates.get("ED25519"))
+    )
+    assertFalse(certHolder.isSignatureValid(S2DKContentVerifierProvider(otherCert)))
+  }
+}

--- a/jvm/common/src/test/kotlin/app/cash/security_sdk/internal/S2DKContentVerifierProviderTest.kt
+++ b/jvm/common/src/test/kotlin/app/cash/security_sdk/internal/S2DKContentVerifierProviderTest.kt
@@ -1,0 +1,51 @@
+package app.cash.security_sdk.internal
+
+import app.cash.security_sdk.CertificateUtil
+import app.cash.security_sdk.SigningCert
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.PublicKeySign
+import com.google.crypto.tink.signature.SignatureConfig
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.bouncycastle.cert.X509CertificateHolder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Period
+
+internal class S2DKContentVerifierProviderTest {
+  private lateinit var signingCert: SigningCert
+  private lateinit var publicKeySign: PublicKeySign
+  private val data = byteArrayOf(0x00, 0x01, 0x02, 0x03)
+
+  @BeforeEach
+  fun setUp() {
+    SignatureConfig.register()
+    val ed25519PrivateKeysetHandle = KeysetHandle.generateNew(KeyTemplates.get("ED25519"))
+    signingCert = CertificateUtil.createRootSigningCertificate(
+      "entity", Period.ofDays(1), ed25519PrivateKeysetHandle
+    )
+    publicKeySign = ed25519PrivateKeysetHandle.getPrimitive(PublicKeySign::class.java)
+  }
+
+  @Test
+  fun `test get() returns content verifier with appropriate key`() {
+    val tinkContentVerifier = S2DKContentVerifierProvider(signingCert).get(
+      AlgorithmIdentifier(
+        ASN1ObjectIdentifier(TinkContentSigner.ED25519_OID)
+      )
+    )
+    tinkContentVerifier.outputStream.write(data)
+    assertTrue(tinkContentVerifier.verify(publicKeySign.sign(data)))
+  }
+
+  @Test
+  fun `test getAssociatedCertificate`() {
+    assertEquals(
+      X509CertificateHolder(signingCert.certificate.toByteArray()),
+      S2DKContentVerifierProvider(signingCert).associatedCertificate
+    )
+  }
+}


### PR DESCRIPTION
Add createRootSigningCertificate() to CertificateUtil.

This method associates an entity name, validity period and Tink Keyset together into a self-signed certificate which can be used as the root of trust for a certificate chain.