### PR TITLE
Change S2DKContentVerifierProducer to be based on SubjectPublicKeyInfo.

### DIFF
--- a/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/S2DKContentVerifierProvider.kt
+++ b/jvm/common/src/main/kotlin/app/cash/security_sdk/internal/S2DKContentVerifierProvider.kt
@@ -1,11 +1,11 @@
 package app.cash.security_sdk.internal
 
-import app.cash.security_sdk.SigningCert
 import com.google.crypto.tink.BinaryKeysetReader
 import com.google.crypto.tink.CleartextKeysetHandle
 import com.google.crypto.tink.PublicKeyVerify
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.operator.ContentVerifier
 import org.bouncycastle.operator.ContentVerifierProvider
@@ -16,13 +16,10 @@ import org.bouncycastle.operator.ContentVerifierProvider
  * keys directly without needing to reason about their internals.
  */
 internal class S2DKContentVerifierProvider(
-  private val signingCert: SigningCert
+  private val subjectPublicKeyInfo: SubjectPublicKeyInfo
 ) : ContentVerifierProvider {
-  private val x509Certificate = X509CertificateHolder(signingCert.certificate.toByteArray())
 
   override fun get(algorithmIdentifer: AlgorithmIdentifier): ContentVerifier {
-    val subjectPublicKeyInfo = x509Certificate.subjectPublicKeyInfo
-
     // TODO(dcashman): this is effectively ignored at the moment, but we should ensure that the
     // the algorithm passed-in matches our expected Tink algorithm ID.
     if (!algorithmIdentifer.equals(AlgorithmIdentifier(ASN1ObjectIdentifier(TinkContentSigner.ED25519_OID)))
@@ -37,11 +34,11 @@ internal class S2DKContentVerifierProvider(
     )
   }
 
-  override fun getAssociatedCertificate(): X509CertificateHolder {
-    return x509Certificate
+  override fun getAssociatedCertificate(): X509CertificateHolder? {
+    return null
   }
 
   override fun hasAssociatedCertificate(): Boolean {
-    return true
+    return false
   }
 }

--- a/jvm/common/src/test/kotlin/app/cash/security_sdk/CertificateUtilTest.kt
+++ b/jvm/common/src/test/kotlin/app/cash/security_sdk/CertificateUtilTest.kt
@@ -70,12 +70,20 @@ internal class CertificateUtilTest {
     val certHolder = X509CertificateHolder(signingCert.certificate.toByteArray())
 
     // Self-signed cert should verify when presented with itself.
-    assertTrue(certHolder.isSignatureValid(S2DKContentVerifierProvider(signingCert)))
+    assertTrue(certHolder.isSignatureValid(S2DKContentVerifierProvider(certHolder.subjectPublicKeyInfo)))
 
     // Different key should not verify
     val otherCert = CertificateUtil.createRootSigningCertificate(
       "entity", Period.ofDays(1), KeysetHandle.generateNew(KeyTemplates.get("ED25519"))
     )
-    assertFalse(certHolder.isSignatureValid(S2DKContentVerifierProvider(otherCert)))
+    assertFalse(
+      certHolder.isSignatureValid(
+        S2DKContentVerifierProvider(
+          X509CertificateHolder(
+            otherCert.certificate.toByteArray()
+          ).subjectPublicKeyInfo
+        )
+      )
+    )
   }
 }

--- a/jvm/common/src/test/kotlin/app/cash/security_sdk/internal/S2DKContentVerifierProviderTest.kt
+++ b/jvm/common/src/test/kotlin/app/cash/security_sdk/internal/S2DKContentVerifierProviderTest.kt
@@ -1,22 +1,19 @@
 package app.cash.security_sdk.internal
 
-import app.cash.security_sdk.CertificateUtil
-import app.cash.security_sdk.SigningCert
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.PublicKeySign
 import com.google.crypto.tink.signature.SignatureConfig
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
-import org.bouncycastle.cert.X509CertificateHolder
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.Period
 
 internal class S2DKContentVerifierProviderTest {
-  private lateinit var signingCert: SigningCert
+  private lateinit var subjectPublicKeyInfo: SubjectPublicKeyInfo
   private lateinit var publicKeySign: PublicKeySign
   private val data = byteArrayOf(0x00, 0x01, 0x02, 0x03)
 
@@ -24,15 +21,13 @@ internal class S2DKContentVerifierProviderTest {
   fun setUp() {
     SignatureConfig.register()
     val ed25519PrivateKeysetHandle = KeysetHandle.generateNew(KeyTemplates.get("ED25519"))
-    signingCert = CertificateUtil.createRootSigningCertificate(
-      "entity", Period.ofDays(1), ed25519PrivateKeysetHandle
-    )
+    subjectPublicKeyInfo = ed25519PrivateKeysetHandle.toSubjectPublicKeyInfo()
     publicKeySign = ed25519PrivateKeysetHandle.getPrimitive(PublicKeySign::class.java)
   }
 
   @Test
   fun `test get() returns content verifier with appropriate key`() {
-    val tinkContentVerifier = S2DKContentVerifierProvider(signingCert).get(
+    val tinkContentVerifier = S2DKContentVerifierProvider(subjectPublicKeyInfo).get(
       AlgorithmIdentifier(
         ASN1ObjectIdentifier(TinkContentSigner.ED25519_OID)
       )
@@ -43,9 +38,6 @@ internal class S2DKContentVerifierProviderTest {
 
   @Test
   fun `test getAssociatedCertificate`() {
-    assertEquals(
-      X509CertificateHolder(signingCert.certificate.toByteArray()),
-      S2DKContentVerifierProvider(signingCert).associatedCertificate
-    )
+    assertNull(S2DKContentVerifierProvider(subjectPublicKeyInfo).associatedCertificate)
   }
 }


### PR DESCRIPTION
This should allow subjectpublickeyinfo extracted from a pkcs10 request to be used directly rather than having to shape it into a temporary certificate object (which is what the request is meant to be used to create).