### PR TITLE
Port: "Add createMobileCertReq API and rm subjectInfo() map."

### DIFF
--- a/jvm/common/src/main/kotlin/app/cash/security_sdk/CertificateRequest.kt
+++ b/jvm/common/src/main/kotlin/app/cash/security_sdk/CertificateRequest.kt
@@ -1,8 +1,7 @@
 package app.cash.security_sdk
 
-import okio.ByteString
+import org.bouncycastle.pkcs.PKCS10CertificationRequest
 
 data class CertificateRequest(
-  val csr: ByteString,
-  val subjectInfo: Map<String, String>,
+  val csr: PKCS10CertificationRequest,
 )


### PR DESCRIPTION
Be explicit about pkcs10 certificate request expected as part of a mobile certificate request, and provide a function to create said requests from entity name and Tink keyset.