### PR TITLE
Implement ASN.1 types as DER encodables

### DIFF
--- a/ios/Example/SecuritySdk.xcodeproj/project.pbxproj
+++ b/ios/Example/SecuritySdk.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		ACB0006DC5CF79D82C70294C /* Pods_SecuritySdk_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3C8548A7560DC459BC9C9FE /* Pods_SecuritySdk_Tests.framework */; };
+		E10D7FCC299410D0002E6B72 /* DEREncodableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10D7FCB299410D0002E6B72 /* DEREncodableTest.swift */; };
 		E17B12F229882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17B12F129882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift */; };
 		F93E384D28DA228D00F05C50 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93E384C28DA228D00F05C50 /* VersionTests.swift */; };
 /* End PBXBuildFile section */
@@ -47,6 +48,7 @@
 		B3C8548A7560DC459BC9C9FE /* Pods_SecuritySdk_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SecuritySdk_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D10EEC24DA7D67721BDB8A54 /* Pods_SecuritySdk_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SecuritySdk_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7107585B17135B120BF57AD /* Pods-SecuritySdk_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SecuritySdk_Tests.release.xcconfig"; path = "Target Support Files/Pods-SecuritySdk_Tests/Pods-SecuritySdk_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		E10D7FCB299410D0002E6B72 /* DEREncodableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DEREncodableTest.swift; sourceTree = "<group>"; };
 		E17B12F129882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureEnclaveDigitalSignatureKeyManagerTests.swift; sourceTree = "<group>"; };
 		F93E384C28DA228D00F05C50 /* VersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -126,6 +128,7 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E10D7FCB299410D0002E6B72 /* DEREncodableTest.swift */,
 				E17B12F129882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift */,
 				F93E384C28DA228D00F05C50 /* VersionTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
@@ -346,6 +349,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F93E384D28DA228D00F05C50 /* VersionTests.swift in Sources */,
+				E10D7FCC299410D0002E6B72 /* DEREncodableTest.swift in Sources */,
 				E17B12F229882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Example/Tests/DEREncodableTest.swift
+++ b/ios/Example/Tests/DEREncodableTest.swift
@@ -1,0 +1,154 @@
+//
+//  DEREncodableTest.swift
+//  SecuritySdk_Tests
+//
+
+import SecuritySdk
+import XCTest
+
+final class DEREncodableTest: XCTestCase {
+    func testDERBitString() throws {
+        let values = [
+            try DERBitString(Data([0b01101110, 0b01011101, 0b11000000])),
+            try DERBitString(Data([0b01101110, 0b01011101, 0b00000000])),
+        ]
+        let expectedValues: [[Octet]] = [
+            [0x03, 0x04, 0x06, 0x6e, 0x5d, 0xc0],
+            [0x03, 0x04, 0x00, 0x6e, 0x5d, 0x00]
+        ]
+
+        for index in 0...1 {
+            XCTAssertEqual(values[index].octets, expectedValues[index])
+        }
+    }
+
+    func testDERBoolean() throws {
+        let values = [
+            try DERBoolean(true),
+            try DERBoolean(false),
+        ]
+        let expectedValues: [[Octet]] = [
+            [0x01, 0x01, 0xff],
+            [0x01, 0x01, 0x00],
+        ]
+
+        for index in 0...1 {
+            XCTAssertEqual(values[index].octets, expectedValues[index])
+        }
+    }
+
+    func testDERInteger() throws {
+        let values = [
+            try DERInteger(0),
+            try DERInteger(127),
+            try DERInteger(128),
+            try DERInteger(256),
+            try DERInteger(-128),
+            try DERInteger(-129),
+        ]
+        let expectedValues: [[Octet]] = [
+            [0x02, 0x01, 0x00],
+            [0x02, 0x01, 0x7f],
+            [0x02, 0x02, 0x00, 0x80],
+            [0x02, 0x02, 0x01, 0x00],
+            [0x02, 0x01, 0x80],
+            [0x02, 0x02, 0xff, 0x7f],
+        ]
+
+        for index in 0...5 {
+            XCTAssertEqual(values[index].octets, expectedValues[index])
+        }
+    }
+
+    func testDERNull() throws {
+        let value = try DERNull()
+        let expectedValue: [Octet] = [0x05, 0x00]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+
+    func testDERObjectIdentifier() throws {
+        let value = try DERObjectIdentifier([1, 2, 840, 113549, 1, 1, 11])
+        let expectedValue: [Octet] = [
+            0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b
+        ]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+
+    func testDERSequence() throws {
+        let value = try DERSequence([
+            try DERObjectIdentifier([1, 2, 840, 113549, 1, 1, 11]),
+            try DERNull()
+        ])
+        let expectedValue: [Octet] = [
+            0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00
+        ]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+
+    func testDERSet() throws {
+        let value = try DERSet([
+            try DERObjectIdentifier([1, 2, 840, 113549, 1, 1, 11]),
+            try DERNull()
+        ])
+        let expectedValue: [Octet] = [
+            0x31, 0x0d, 0x05, 0x00, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b
+        ]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+    
+    func testDERIA5String() throws {
+        let value = try DERIA5String("hi")
+        let expectedValue: [Octet] = [0x16, 0x02, 0x68, 0x69]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+    
+    func testDEROctetString() throws {
+        let value = try DEROctetString(Data([0x03, 0x02, 0x06, 0xa0]))
+        let expectedValue: [Octet] = [0x04, 0x04, 0x03, 0x02, 0x06, 0xa0]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+    
+    func testDERPrintableString() throws {
+        let value = try DERPrintableString("hi")
+        let expectedValue: [Octet] = [0x13, 0x02, 0x68, 0x69]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+    
+    func testDERUTCTime() throws {
+        // "2023-02-13T20:09:30Z"
+        let value = try DERUTCTime(Date(timeIntervalSince1970: TimeInterval(1676318970)))
+        let expectedValue: [Octet] = [0x17, 0x0d, 0x31, 0x36, 0x37, 0x36, 0x33, 0x31, 0x38, 0x39, 0x37, 0x30, 0x2e, 0x30, 0x5a]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+    
+    func testDERUTF8String() throws {
+        let value = try DERUTF8String("😎")
+        let expectedValue: [Octet] = [0x0c, 0x04, 0xf0, 0x9f, 0x98, 0x8e]
+
+        XCTAssertEqual(value.octets, expectedValue)
+    }
+    
+    func testDERPrintableStringFails_withIllegalCharacters() throws {
+        XCTAssertThrowsError(try DERPrintableString("hi@me.com"))
+    }
+    
+    func testDERObjectIdentifierFails_withSingleComponent() throws {
+        XCTAssertThrowsError(try DERObjectIdentifier([1]))
+    }
+    
+    func testDERObjectIdentifierFails_withFirstComponentOutOfRange() throws {
+        XCTAssertThrowsError(try DERObjectIdentifier([3]))
+    }
+    
+    func testDERObjectIdentifierFails_withSecondComponentOutOfRange() throws {
+        XCTAssertThrowsError(try DERObjectIdentifier([1, 40]))
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1Type.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1Type.swift
@@ -1,0 +1,90 @@
+//
+//  ASN1Type.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+public typealias Octet = UInt8
+
+/// Base ASN.1 type that is conformed by a DER type
+public protocol ASN1Type {
+    /// tag octet
+    var tag: Octet { get }
+    /// tag-length-value octets
+    var octets: [Octet] { get }
+}
+
+// MARK: - Type
+
+public enum Type {
+    case none
+    case implicit(_ specificTag: Octet)
+    case explicit(_ specificTag: Octet)
+}
+
+// MARK: - Tag
+
+public enum Tag {
+    case boolean(_ type: Type)
+    case integer(_ type: Type)
+    case bitString(_ type: Type)
+    case octetString(_ type: Type)
+    case null(_ type: Type)
+    case objectIdentifier(_ type: Type)
+    case utf8String(_ type: Type)
+    case sequence(_ type: Type)
+    case set(_ type: Type)
+    case printableString(_ type: Type)
+    case ia5String(_ type: Type)
+    case utcTime(_ type: Type)
+    
+    /// ASN.1 types
+    var type: Type {
+        switch self {
+        case let .boolean(type),
+            let .integer(type),
+            let .bitString(type),
+            let .octetString(type),
+            let .null(type),
+            let .objectIdentifier(type),
+            let .utf8String(type),
+            let .sequence(type),
+            let .set(type),
+            let .printableString(type),
+            let .ia5String(type),
+            let .utcTime(type):
+            return type
+        }
+    }
+    
+    /// ASN.1 tag value (non-encoding form)
+    var value: Octet {
+        switch self {
+        case .boolean:
+            return 0x01
+        case .integer:
+            return 0x02
+        case .bitString:
+            return 0x03
+        case .octetString:
+            return 0x04
+        case .null:
+            return 0x05
+        case .objectIdentifier:
+            return 0x06
+        case .utf8String:
+            return 0x0c
+        case .sequence:
+            return 0x10
+        case .set:
+            return 0x11
+        case .printableString:
+            return 0x13
+        case .ia5String:
+            return 0x16
+        case .utcTime:
+            return 0x17
+        }
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERBitString.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERBitString.swift
@@ -1,0 +1,37 @@
+//
+//  DERBitString.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// BitString DER (Distingushed Encoding Rules) encodable
+public struct DERBitString: ASN1Type, DEREncodable {
+    public typealias T = Data
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ rawValue: Data, _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .bitString(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: Data) -> [Octet] {
+        let value = [Octet](rawValue)
+        
+        let leastSignificantOctet = value.last!
+        let unusedBits: Octet
+        if (leastSignificantOctet.trailingZeroBitCount < Octet.bitWidth) {
+            unusedBits = Octet(leastSignificantOctet.trailingZeroBitCount)
+        } else {
+            unusedBits = Octet(0x00)
+        }
+        
+        return [unusedBits] + value
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERBoolean.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERBoolean.swift
@@ -1,0 +1,30 @@
+//
+//  DERBoolean.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Boolean DER (Distingushed Encoding Rules) encodable
+public struct DERBoolean: ASN1Type, DEREncodable {
+    public typealias T = Bool
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ rawValue: Bool, _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .boolean(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: Bool) -> [Octet] {
+        if (rawValue) {
+            return [0xff]
+        }
+        return [0x00]
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DEREncodable.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DEREncodable.swift
@@ -1,0 +1,156 @@
+//
+//  DEREncodable.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Base DER (Distingushed Encoding Rules) encodable that is conformed by a DER struct
+protocol DEREncodable {
+    associatedtype T
+
+    /**
+     Encodes the raw value to DER encoded value octets
+     
+     - parameter rawValue: the raw value to encode from
+     - returns: the asn.1 DER encoded value octets
+     */
+    static func encodeValue(_ rawValue: T) -> [Octet]
+}
+
+// MARK: -
+
+extension DEREncodable {
+    /**
+     Encodes the raw value to DER encoded octets
+     
+     - parameter rawValue: the raw value to encode from
+     - parameter tag: the tag that identifies the DER type
+     - returns: the asn.1 DER encoded octets
+     */
+    static func encode(_ rawValue: T, _ tag: Tag) throws -> [Octet] {
+        let value = encodeValue(rawValue)
+        let length = try encodeLength(value.count)
+        let content = length + value
+        
+        switch tag.type {
+        case .none:
+            return [tag.value | tag.encodingForm] + content
+        case .implicit(let specificTag):
+            return [0x80 | (0x0f & specificTag) | tag.encodingForm] + content
+        case .explicit(let specificTag):
+            let innerContent = [tag.value | tag.encodingForm] + content
+
+            return [0xa0 | (0x0f & specificTag)]
+            + (try encodeLength(innerContent.count))
+            + innerContent
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    /**
+     Encodes the length to DER encoded octets of either:
+        (1) Short-form: 1 octet long
+        (2) Long-form: 2...127 octets long
+     
+     - parameter length: the length to encode
+     - returns: the asn.1 DER encoded length octets
+     */
+    private static func encodeLength(_ length: Int) throws -> [Octet] {
+        if (length < 128) {
+            return base128(UInt(length))
+        }
+        
+        let result: [Octet] = base256(Int64(length))
+        let count = result.count
+        // sanity check that count is at most 126
+        guard (count <= 126) else {
+            throw DEREncodableError.unhandled("Exceeds definite length limits of 126 bytes")
+        }
+        
+        return [Octet(count) | 0x80] + result
+    }
+
+    // MARK: - Internal Methods
+
+    /**
+     Encodes the value to DER encoded octets in base-128
+
+     - parameter value: the value to encode
+     - parameter highBit: optional sets high bits of the octet for certain encodings
+     - returns: the asn.1 DER encoded octets in base-128
+     */
+    internal static func base128(_ value: UInt, _ highBit: Octet = 0x00) -> [Octet] {
+        if (value == 0) {
+            return [0x00]
+        }
+
+        var valCopy = value >> 7
+        var result: [Octet] = [Octet(value & 0x7f)]
+
+        while valCopy > 0 {
+            result = [Octet(valCopy & 0x7f) | highBit] + result
+            valCopy >>= 7
+        }
+
+        return result
+    }
+
+    /**
+     Encodes the value to DER encoded octets in base-256
+
+     - parameter value: the value to encode
+     - returns: the asn.1 DER encoded octets in base-256
+     */
+    internal static func base256(_ value: Int64) -> [Octet] {
+        if (value == 0) {
+            return [0x00]
+        }
+
+        let numberOfBits = Double(Int64.bitWidth - abs(value).leadingZeroBitCount)
+        let minimumOctets = Int(ceil(numberOfBits / Double(8)))
+        
+        var result: [Octet] = []
+        var valCopy = value
+        
+        for _ in 1...minimumOctets {
+            result = [Octet(valCopy & 0xff)] + result
+            valCopy >>= 8
+        }
+
+        return result
+    }
+}
+
+// MARK: -
+
+extension Tag {
+    /// ASN.1 DER encoding form
+    var encodingForm: Octet {
+        switch self {
+        // constructed
+        case .sequence, .set:
+            return 0x20
+        // primitive
+        default:
+            return 0x00
+        }
+    }
+}
+
+
+// MARK: -
+
+public enum DEREncodableError: LocalizedError {
+    case invalidInput(String)
+    case unhandled(String)
+    
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidInput(error),
+            let .unhandled(error):
+            return error
+        }
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERIA5String.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERIA5String.swift
@@ -1,0 +1,27 @@
+//
+//  DERIA5String.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// IA5String DER (Distingushed Encoding Rules) encodable
+public struct DERIA5String: ASN1Type, DEREncodable {
+    public typealias T = String
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ rawValue: String, _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .ia5String(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: String) -> [Octet] {
+        return rawValue.compactMap { $0.asciiValue }
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERInteger.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERInteger.swift
@@ -1,0 +1,44 @@
+//
+//  DERInteger.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Integer DER (Distingushed Encoding Rules) encodable
+public struct DERInteger: ASN1Type, DEREncodable {
+    public typealias T = Int64
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ rawValue: Int64, _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .integer(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: Int64) -> [Octet] {
+        if (rawValue == 0) {
+            return [0x00]
+        }
+        
+        let result = base256(rawValue)
+        let signum = rawValue.signum()
+            
+        if (signum == 1) {
+            if (result[0] & 0x80 == 0x80) {
+                return [0x00] + result
+            }
+        } else {
+            if (result[0] & 0x80 == 0x00) {
+                return [0xff] + result
+            }
+        }
+        
+        return result
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERNull.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERNull.swift
@@ -1,0 +1,27 @@
+//
+//  DERNull.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Null DER (Distingushed Encoding Rules) encodable
+public struct DERNull: ASN1Type, DEREncodable {
+    public typealias T = Any?
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ type: Type = Type.none) throws {
+        self.octets = try Self.encode(nil, .null(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: Any? = nil) -> [Octet] {
+        return []
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERObjectIdentifier.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERObjectIdentifier.swift
@@ -1,0 +1,53 @@
+//
+//  DERObjectIdentifier.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// ObjectIdentifier DER (Distingushed Encoding Rules) encodable
+public struct DERObjectIdentifier: ASN1Type, DEREncodable {
+    public typealias T = [UInt]
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ rawValue: [UInt], _ type: Type = Type.none) throws {
+        guard rawValue.count >= 2 else {
+            throw DEREncodableError.invalidInput(
+                "Requires at least two components"
+            )
+        }
+        guard (0...1).contains(rawValue[0]) else {
+            throw DEREncodableError.invalidInput(
+                "Out of Range - Component[0] must be within (0, 1)"
+            )
+        }
+        guard (0...39).contains(rawValue[1]) else {
+            throw DEREncodableError.invalidInput(
+                "Out of Range - Component[1] must be within (0, 39)"
+            )
+        }
+        
+        self.octets = try Self.encode(rawValue, .objectIdentifier(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: [UInt]) -> [Octet] {
+        var result: [Octet] = [Octet(40 * rawValue[0] + rawValue[1])]
+        
+        if (rawValue.count == 2) {
+            return result
+        }
+        
+        for component in rawValue[2...] {
+            result += base128(component, 0x80)
+        }
+
+        return result
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DEROctetString.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DEROctetString.swift
@@ -1,0 +1,27 @@
+//
+//  DEROctetString.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// OctetString DER (Distingushed Encoding Rules) encodable
+public struct DEROctetString: ASN1Type, DEREncodable {
+    public typealias T = Data
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ rawValue: Data, _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .octetString(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: Data) -> [Octet] {
+        return [Octet](rawValue)
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERPrintableString.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERPrintableString.swift
@@ -1,0 +1,36 @@
+//
+//  DERPrintableString.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// PrintableString DER (Distingushed Encoding Rules) encodable
+public struct DERPrintableString: ASN1Type, DEREncodable {
+    public typealias T = String
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+
+    // MARK: - Initialization
+    
+    public init(_ rawValue: String, _ type: Type = Type.none) throws {
+        guard rawValue.range(
+            of: "^[a-zA-Z0-9'()+,-./:=? ]*$",
+            options: .regularExpression,
+            range: nil,
+            locale: nil
+        ) != nil else {
+            throw DEREncodableError.invalidInput("Illegal character(s) present")
+        }
+
+        self.octets = try Self.encode(rawValue, .printableString(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: String) -> [Octet] {
+        return rawValue.compactMap { $0.asciiValue }
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERSequence.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERSequence.swift
@@ -1,0 +1,27 @@
+//
+//  DERSequence.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Sequence DER (Distingushed Encoding Rules) encodable
+public struct DERSequence: ASN1Type, DEREncodable {
+    public typealias T = [any ASN1Type]
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ rawValue: [any ASN1Type], _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .sequence(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: [any ASN1Type]) -> [Octet] {
+        return rawValue.flatMap { $0.octets }
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERSet.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERSet.swift
@@ -1,0 +1,27 @@
+//
+//  DERSet.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Set DER (Distingushed Encoding Rules) encodable
+public struct DERSet: ASN1Type, DEREncodable {
+    public typealias T = [any ASN1Type]
+
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+    
+    // MARK: - Initialization
+    
+    public init(_ rawValue: [any ASN1Type], _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .set(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: [any ASN1Type]) -> [Octet] {
+        return rawValue.sorted(by: { $0.tag < $1.tag }).flatMap { $0.octets }
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERUTCTime.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERUTCTime.swift
@@ -1,0 +1,27 @@
+//
+//  DERUTCTime.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// UTCTime DER (Distingushed Encoding Rules) encodable
+public struct DERUTCTime: ASN1Type, DEREncodable {
+    public typealias T = Date
+        
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+
+    // MARK: - Initialization
+    
+    public init(_ rawValue: Date, _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .utcTime(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: Date) -> [Octet] {
+        return (String(rawValue.timeIntervalSince1970) + "Z").compactMap { $0.asciiValue }
+    }
+}

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DERUTF8String.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DERUTF8String.swift
@@ -1,0 +1,27 @@
+//
+//  DERUTF8String.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// UTF8String DER (Distingushed Encoding Rules) encodable
+public struct DERUTF8String: ASN1Type, DEREncodable {
+    public typealias T = String
+    
+    // MARK: - Public Properties
+
+    public let tag: Octet
+    public let octets: [Octet]
+
+    // MARK: - Initialization
+    
+    public init(_ rawValue: String, _ type: Type = Type.none) throws {
+        self.octets = try Self.encode(rawValue, .utf8String(type))
+        self.tag = octets.first!
+    }
+    
+    internal static func encodeValue(_ rawValue: String) -> [Octet] {
+        return Array(rawValue.utf8)
+    }
+}


### PR DESCRIPTION
## Description

This PR introduces ASN.1 types with DER (Distinguished Encoding Rules) encodables that serve as the building blocks for future work on PKCS related formats that require DER encoded octets.