### PR TITLE
Allow public key to be exportable

### DIFF
--- a/ios/Example/Tests/SecureEnclaveDigitalSignatureKeyManagerTests.swift
+++ b/ios/Example/Tests/SecureEnclaveDigitalSignatureKeyManagerTests.swift
@@ -26,6 +26,10 @@ final class SecureEnclaveDigitalSignatureKeyManagerTests: XCTestCase {
         XCTAssertEqual(verified, true)
     }
     
+    func testExportVerifyingKeyDataSucceeds() throws {
+        XCTAssertNoThrow(try manager.verifyingKey().exportAsData())
+    }
+    
     func testSignatureVerificationFails_whenVerifyingOtherData() throws {
         let data = "hello world".data(using: .utf8)!
         let otherData = "bye world".data(using: .utf8)!

--- a/ios/SecuritySdk/Classes/CryptographicKey.swift
+++ b/ios/SecuritySdk/Classes/CryptographicKey.swift
@@ -33,6 +33,17 @@ protocol SigningKey: CryptographicKey {
 /// Verifying key of the digital signature keypair
 protocol VerifyingKey: CryptographicKey {
     var publicKey: SecKey { get }
+    
+    /**
+     Returns an external representation of the given key
+     depending on its key type (pkcs#1 for RSA keys for example).
+         
+     - throws: an error type `CryptographicKeyError` when the operation
+        fails if the key is not exportable, for example if it is bound to a smart card
+        or to the Secure Enclave
+     - returns: the encoded public key as bytes
+     */
+    func exportAsData() throws -> Data
 
     /**
      Verifies the signature using the public key with the provided data
@@ -48,6 +59,7 @@ protocol VerifyingKey: CryptographicKey {
 
 public enum CryptographicKeyError: LocalizedError {
     case unavailablePublicKey
+    case unexportablePublicKey
     case unsupportedAlgorithm
     case unhandled(Error)
     
@@ -55,6 +67,8 @@ public enum CryptographicKeyError: LocalizedError {
         switch self {
         case .unavailablePublicKey:
             return "Public key is unavailable."
+        case .unexportablePublicKey:
+            return "Public key cannot be exported."
         case .unsupportedAlgorithm:
             return "Invalid algorithm used."
         case let .unhandled(error):

--- a/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveVerifyingKey.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveVerifyingKey.swift
@@ -22,6 +22,17 @@ public struct SecureEnclaveVerifyingKey: VerifyingKey {
     }
 
     // MARK: - Public Class Methods (VerifyingKey)
+    
+    public func exportAsData() throws -> Data {
+        var error: Unmanaged<CFError>?
+        guard let data = SecKeyCopyExternalRepresentation(
+            publicKey,
+            &error
+        ) as? Data else {
+            throw CryptographicKeyError.unexportablePublicKey
+        }
+        return data
+    }
 
     public func verify(data: Data, with signature: Data) -> Bool {
         var error: Unmanaged<CFError>?


### PR DESCRIPTION
## Description

This PR exposes a convenience method for PublicKey types to be able to export its material as an external representation and encoded appropriately depending on is algorithm type. 