### PR TITLE
Hide key abstration away with signer and verifier protocols

### DIFF
--- a/ios/Example/Tests/SecureEnclaveDigitalSignatureKeyManagerTests.swift
+++ b/ios/Example/Tests/SecureEnclaveDigitalSignatureKeyManagerTests.swift
@@ -17,28 +17,24 @@ final class SecureEnclaveDigitalSignatureKeyManagerTests: XCTestCase {
     func testSignAndVerifySucceeds() throws {
         let data = "hello world".data(using: .utf8)!
 
-        let signingKey = try manager.signingKey()
-        let signature = try signingKey.sign(with: data)
+        let signature = try manager.sign(with: data)
 
-        let verifyingKey = try manager.verifyingKey()
-        let verified = verifyingKey.verify(data: data, with: signature)
+        let verified = try manager.verify(data: data, with: signature)
 
         XCTAssertEqual(verified, true)
     }
     
     func testExportVerifyingKeyDataSucceeds() throws {
-        XCTAssertNoThrow(try manager.verifyingKey().exportAsData())
+        XCTAssertNoThrow(try manager.exportVerifyingKey())
     }
     
     func testSignatureVerificationFails_whenVerifyingOtherData() throws {
         let data = "hello world".data(using: .utf8)!
         let otherData = "bye world".data(using: .utf8)!
 
-        let signingKey = try manager.signingKey()
-        let signature = try signingKey.sign(with: data)
+        let signature = try manager.sign(with: data)
 
-        let verifyingKey = try manager.verifyingKey()
-        let verified = verifyingKey.verify(data: otherData, with: signature)
+        let verified = try manager.verify(data: otherData, with: signature)
 
         XCTAssertEqual(verified, false)
     }
@@ -46,11 +42,9 @@ final class SecureEnclaveDigitalSignatureKeyManagerTests: XCTestCase {
     func testSignatureVerificationFails_whenVerifyingWithDifferentKey() throws {
         let data = "hello world".data(using: .utf8)!
 
-        let signingKey = try manager.signingKey()
-        let signature = try signingKey.sign(with: data)
+        let signature = try manager.sign(with: data)
 
-        let otherVerifyingKey = try otherManager.verifyingKey()
-        let verified = otherVerifyingKey.verify(data: data, with: signature)
+        let verified = try otherManager.verify(data: data, with: signature)
 
         XCTAssertEqual(verified, false)
     }

--- a/ios/SecuritySdk/Classes/CryptographicKey.swift
+++ b/ios/SecuritySdk/Classes/CryptographicKey.swift
@@ -33,17 +33,6 @@ protocol SigningKey: CryptographicKey {
 /// Verifying key of the digital signature keypair
 protocol VerifyingKey: CryptographicKey {
     var publicKey: SecKey { get }
-    
-    /**
-     Returns an external representation of the given key
-     depending on its key type (pkcs#1 for RSA keys for example).
-         
-     - throws: an error type `CryptographicKeyError` when the operation
-        fails if the key is not exportable, for example if it is bound to a smart card
-        or to the Secure Enclave
-     - returns: the encoded public key as bytes
-     */
-    func exportAsData() throws -> Data
 
     /**
      Verifies the signature using the public key with the provided data

--- a/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureKeyManager.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureKeyManager.swift
@@ -25,4 +25,15 @@ protocol DigitalSignatureKeyManager {
      - returns: the public key for verifying
      */
     func verifyingKey() throws -> PublicKey
+    
+    /**
+     Returns an external representation of the given key
+     depending on its key type (pkcs#1 for RSA or ANSI X9.63 format for EC).
+         
+     - throws: an error type `CryptographicKeyError` when the operation
+        fails if the key is not exportable, for example if it is bound to a smart card
+        or to the Secure Enclave
+     - returns: the encoded public key as bytes
+     */
+    func exportVerifyingKey() throws -> Data
 }

--- a/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureSigner.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureSigner.swift
@@ -1,0 +1,19 @@
+//
+//  DigitalSignatureSigner.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Signer to perform digital signature signing operations
+public protocol DigitalSignatureSigner {
+    /**
+     Signs a blob of data with the underlying signing key
+     
+     - throws: an error type `CryptographicKeyError` if the
+        signing operation cannot be completed due to the underlying
+        signing key being unavailable.
+     - returns: the signature of the signing operation result
+     */
+    func sign(with data: Data) throws -> Data
+}

--- a/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureVerifier.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureVerifier.swift
@@ -1,0 +1,19 @@
+//
+//  DigitalSignatureVerifier.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Verifier to perform digital signature verification operations
+public protocol DigitalSignatureVerifier {
+    /**
+     Verifies a blob of data with a supplied signature using the underlying verifying key
+     
+     - throws: an error type `CryptographicKeyError` if the
+        verifying operation cannot be completed due to the underlying
+        verifying key being unavailable.
+     - returns: true if the signature is verified, false otherwise
+     */
+    func verify(data: Data, with signature: Data) throws -> Bool
+}

--- a/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveSigningKey.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveSigningKey.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SecureEnclaveSigningKey: SigningKey {
+internal struct SecureEnclaveSigningKey: SigningKey {
     
     // MARK: - Internal Properties
     
@@ -21,9 +21,9 @@ public struct SecureEnclaveSigningKey: SigningKey {
         self.privateKey = secKey
     }
 
-    // MARK: - Public Class Methods (SigningKey)
+    // MARK: - Internal Class Methods (SigningKey)
 
-    public func sign(with data: Data) throws -> Data {
+    internal func sign(with data: Data) throws -> Data {
         var error: Unmanaged<CFError>?
         guard let signature = SecKeyCreateSignature(
             privateKey,

--- a/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveVerifyingKey.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveVerifyingKey.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct SecureEnclaveVerifyingKey: VerifyingKey {
+internal struct SecureEnclaveVerifyingKey: VerifyingKey {
 
     // MARK: - Internal Properties
 
@@ -21,20 +21,9 @@ public struct SecureEnclaveVerifyingKey: VerifyingKey {
         self.publicKey = secKey
     }
 
-    // MARK: - Public Class Methods (VerifyingKey)
-    
-    public func exportAsData() throws -> Data {
-        var error: Unmanaged<CFError>?
-        guard let data = SecKeyCopyExternalRepresentation(
-            publicKey,
-            &error
-        ) as? Data else {
-            throw CryptographicKeyError.unexportablePublicKey
-        }
-        return data
-    }
+    // MARK: - Internal Class Methods (VerifyingKey)
 
-    public func verify(data: Data, with signature: Data) -> Bool {
+    internal func verify(data: Data, with signature: Data) -> Bool {
         var error: Unmanaged<CFError>?
         guard SecKeyVerifySignature(
             self.publicKey,


### PR DESCRIPTION
## Description

This hides away the key abstraction and surfaces two protocols to perform the signing and verification operations. 