### PR TITLE
Surface higher abstractions for digital signature and public key

### DIFF
--- a/ios/Example/Tests/SecureEnclaveDigitalSignatureKeyManagerTests.swift
+++ b/ios/Example/Tests/SecureEnclaveDigitalSignatureKeyManagerTests.swift
@@ -19,13 +19,9 @@ final class SecureEnclaveDigitalSignatureKeyManagerTests: XCTestCase {
 
         let signature = try manager.sign(with: data)
 
-        let verified = try manager.verify(data: data, with: signature)
+        let verified = try manager.verify(data: data, with: signature.data)
 
         XCTAssertEqual(verified, true)
-    }
-    
-    func testExportVerifyingKeyDataSucceeds() throws {
-        XCTAssertNoThrow(try manager.exportVerifyingKey())
     }
     
     func testSignatureVerificationFails_whenVerifyingOtherData() throws {
@@ -34,7 +30,7 @@ final class SecureEnclaveDigitalSignatureKeyManagerTests: XCTestCase {
 
         let signature = try manager.sign(with: data)
 
-        let verified = try manager.verify(data: otherData, with: signature)
+        let verified = try manager.verify(data: otherData, with: signature.data)
 
         XCTAssertEqual(verified, false)
     }
@@ -44,7 +40,7 @@ final class SecureEnclaveDigitalSignatureKeyManagerTests: XCTestCase {
 
         let signature = try manager.sign(with: data)
 
-        let verified = try otherManager.verify(data: data, with: signature)
+        let verified = try otherManager.verify(data: data, with: signature.data)
 
         XCTAssertEqual(verified, false)
     }

--- a/ios/SecuritySdk/Classes/ASN.1/DER/DEREncodable.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/DER/DEREncodable.swift
@@ -139,7 +139,6 @@ extension Tag {
     }
 }
 
-
 // MARK: -
 
 public enum DEREncodableError: LocalizedError {

--- a/ios/SecuritySdk/Classes/CryptographicKey.swift
+++ b/ios/SecuritySdk/Classes/CryptographicKey.swift
@@ -6,14 +6,12 @@
 import Foundation
 
 protocol CryptographicKey {
-    static var algorithm: SecKeyAlgorithm { get }
-    
     /**
-     Initializer that wraps an instance of `SecKey`
+     Initializer that wraps an instance of `SecKey` and `SecKeyAlgorithm`
      
      - throws: an error type `CryptographicKeyError`
      */
-    init(secKey: SecKey) throws
+    init(_ secKey: SecKey, _ algorithm: SecKeyAlgorithm) throws
 }
 
 /// Signing key of the digital signature keypair
@@ -38,10 +36,21 @@ protocol VerifyingKey: CryptographicKey {
      Verifies the signature using the public key with the provided data
      
      - parameter data: the data to verify
-     - parameter signature: the signature to verify against
+     - parameter signature: the signature data  to verify against
      - returns: true if the signature is verified, false otherwise
      */
     func verify(data: Data, with signature: Data) -> Bool
+    
+    /**
+     Returns an external representation of the given key
+     depending on its key type (pkcs#1 for RSA or ANSI X9.63 format for EC).
+         
+     - throws: an error type `CryptographicKeyError` when the operation
+        fails if the key is not exportable, for example if it is bound to a smart card
+        or to the Secure Enclave
+     - returns: the encoded public key as bytes
+     */
+    func export() throws -> Data
 }
 
 // MARK: -

--- a/ios/SecuritySdk/Classes/Digital Signature/ContentSigner.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/ContentSigner.swift
@@ -1,0 +1,19 @@
+//
+//  ContentSigner.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Inherits `DigitalSignatureSigner` to add the requirement
+///  of exporting the public key
+protocol ContentSigner: DigitalSignatureSigner {
+    /**
+     Exports a `SigningPublicKey`
+     
+     - throws: an error type `CryptographicKeyError` when the
+        operation fails if the key is not exportable
+     - returns: the signing public key along with its key type
+     */
+    func exportPublicKey() throws -> SigningPublicKey
+}

--- a/ios/SecuritySdk/Classes/Digital Signature/DigitalSignature.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/DigitalSignature.swift
@@ -1,0 +1,18 @@
+//
+//  DigitalSignature.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Digital Signature is an external wrapper that provides both the
+///  signing curve algorithm used for signing and the signature data
+public struct DigitalSignature {
+    public let signingAlgorithm: SigningAlgorithm
+    public let data: Data
+    
+    init(signingAlgorithm: SigningAlgorithm, data: Data) {
+        self.signingAlgorithm = signingAlgorithm
+        self.data = data
+    }
+}

--- a/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureKeyManager.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureKeyManager.swift
@@ -10,6 +10,8 @@ protocol DigitalSignatureKeyManager {
     associatedtype PrivateKey
     associatedtype PublicKey
 
+    static var keyType: KeyType { get }
+    
     /**
      Fetches the signing key
      
@@ -25,15 +27,4 @@ protocol DigitalSignatureKeyManager {
      - returns: the public key for verifying
      */
     func verifyingKey() throws -> PublicKey
-    
-    /**
-     Returns an external representation of the given key
-     depending on its key type (pkcs#1 for RSA or ANSI X9.63 format for EC).
-         
-     - throws: an error type `CryptographicKeyError` when the operation
-        fails if the key is not exportable, for example if it is bound to a smart card
-        or to the Secure Enclave
-     - returns: the encoded public key as bytes
-     */
-    func exportVerifyingKey() throws -> Data
 }

--- a/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureSigner.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/DigitalSignatureSigner.swift
@@ -13,7 +13,8 @@ public protocol DigitalSignatureSigner {
      - throws: an error type `CryptographicKeyError` if the
         signing operation cannot be completed due to the underlying
         signing key being unavailable.
-     - returns: the signature of the signing operation result
+     - returns: the digital signature which includes the signature data
+        and the algorithm used for signing
      */
-    func sign(with data: Data) throws -> Data
+    func sign(with data: Data) throws -> DigitalSignature
 }

--- a/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveKeychainQueries.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveKeychainQueries.swift
@@ -29,11 +29,15 @@ internal struct SecureEnclaveKeychainQueries: KeychainQueries {
     }
     
     // MARK: - Internal Methods
-    
-    internal static func attributes(with applicationTag: String) throws -> NSMutableDictionary {
+
+    internal static func attributes(
+        with applicationTag: String,
+        keyType: CFString,
+        keySize: Int
+    ) throws -> NSMutableDictionary {
         let attributes: NSMutableDictionary = [
-            kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
-            kSecAttrKeySizeInBits: 256,
+            kSecAttrKeyType: keyType,
+            kSecAttrKeySizeInBits: keySize,
             kSecPrivateKeyAttrs: [
                 kSecAttrIsPermanent: true,
                 kSecAttrApplicationTag: applicationTag.data(using: .utf8)!,

--- a/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveSigningKey.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/Secure Enclave/SecureEnclaveSigningKey.swift
@@ -9,16 +9,17 @@ internal struct SecureEnclaveSigningKey: SigningKey {
     
     // MARK: - Internal Properties
     
-    internal static let algorithm: SecKeyAlgorithm = .ecdsaSignatureMessageX962SHA256
     internal let privateKey: SecKey
+    internal let algorithm: SecKeyAlgorithm
     
     // MARK: - Initialization
 
-    init(secKey: SecKey) throws {
-        guard SecKeyIsAlgorithmSupported(secKey, .sign, Self.algorithm) else {
+    init(_ secKey: SecKey, _ algorithm: SecKeyAlgorithm) throws {
+        guard SecKeyIsAlgorithmSupported(secKey, .sign, algorithm) else {
             throw CryptographicKeyError.unsupportedAlgorithm
         }
         self.privateKey = secKey
+        self.algorithm = algorithm
     }
 
     // MARK: - Internal Class Methods (SigningKey)
@@ -26,8 +27,8 @@ internal struct SecureEnclaveSigningKey: SigningKey {
     internal func sign(with data: Data) throws -> Data {
         var error: Unmanaged<CFError>?
         guard let signature = SecKeyCreateSignature(
-            privateKey,
-            Self.algorithm,
+            self.privateKey,
+            self.algorithm,
             data as CFData,
             &error
         ) as Data? else {

--- a/ios/SecuritySdk/Classes/Digital Signature/SigningPublicKey.swift
+++ b/ios/SecuritySdk/Classes/Digital Signature/SigningPublicKey.swift
@@ -1,0 +1,18 @@
+//
+//  SigningPublicKey.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// SigningPublicKey is an external wrapper that provides both the
+///  key type used and the public key data
+public struct SigningPublicKey {
+    public let keyType: KeyType
+    public let data: Data
+    
+    init(keyType: KeyType, data: Data) {
+        self.keyType = keyType
+        self.data = data
+    }
+}

--- a/ios/SecuritySdk/Classes/EllipticCurve.swift
+++ b/ios/SecuritySdk/Classes/EllipticCurve.swift
@@ -1,0 +1,23 @@
+//
+//  EllipticCurve.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// The cryptographic curve algorithm
+public enum EllipticCurve {
+    /// Prime256v1 (256-bit prime field Weierstrass curve)
+    case p256(_ kAttr: CFString, _ bitSize: Int)
+    
+    /// Returns a tuple of the SecKey key type attribute
+    /// and key size (in bits)
+    var attrs: (CFString, Int) {
+        get {
+            switch self {
+            case let .p256(kAttr, bitSize):
+                return (kAttr, bitSize)
+            }
+        }
+    }
+}

--- a/ios/SecuritySdk/Classes/KeyType.swift
+++ b/ios/SecuritySdk/Classes/KeyType.swift
@@ -1,0 +1,30 @@
+//
+//  KeyType.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// Represents the key type and algorithm used for the construction of the managed key
+public enum KeyType {
+    /// Elliptic Curve Cryptographic key type
+    case ecKey(_ curve: EllipticCurve, _ signingAlgorithm: SigningAlgorithm)
+    
+    var curve: EllipticCurve {
+        get {
+            switch self {
+            case let .ecKey(curve, _):
+                return curve
+            }
+        }
+    }
+    
+    var signingAlgorithm: SigningAlgorithm {
+        get {
+            switch self {
+            case let .ecKey(_, signingAlgorithm):
+                return signingAlgorithm
+            }
+        }
+    }
+}

--- a/ios/SecuritySdk/Classes/SigningAlgorithm.swift
+++ b/ios/SecuritySdk/Classes/SigningAlgorithm.swift
@@ -1,0 +1,23 @@
+//
+//  SigningAlgorithm.swift
+//  SecuritySdk
+//
+
+import Foundation
+
+/// The signing algorithm
+public enum SigningAlgorithm {
+    /// Elliptic Curve Digital Signature Algorithm (DSA) coupled
+    /// with the Secure Hash Algorithm 256 (SHA256) algorithm
+    case ecdsaSha256(_ keyAlgorithm: SecKeyAlgorithm)
+    
+    /// Signing algorithm used for the specific curve type
+    var attrs: SecKeyAlgorithm {
+        get {
+            switch self {
+            case let .ecdsaSha256(keyAlgorithm):
+                return keyAlgorithm
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
In order to reduce the scope of access to the raw keypairs, the `sign` method returns a new higher abstraction for `DigitalSignature` that provides the context of the signing algorithm along with the signature data.  An extended protocol `ContentSigner` which extends the protocol `DigitalSignatureSigner` to surface the public key `SigningPublicKey` when appropriate. 