### PR TITLE
Implement BC content verifier for raw key types

### DIFF
--- a/jvm/src/main/kotlin/app/cash/security_sdk/internal/TrifleAlgorithmIdentifier.kt
+++ b/jvm/src/main/kotlin/app/cash/security_sdk/internal/TrifleAlgorithmIdentifier.kt
@@ -10,15 +10,19 @@ sealed class TrifleAlgorithmIdentifier(
   // Defined in https://www.rfc-editor.org/rfc/rfc8420
   // Registry http://oid-info.com/cgi-bin/display?oid=1.3.101.112&a=display
   // TODO(dcashman): Define a custom OID based on tink primitives.
-  object TinkAlgorithmIdentifier: TrifleAlgorithmIdentifier("1.3.101.112")
+  object TinkAlgorithmIdentifier: TrifleAlgorithmIdentifier(oid = "1.3.101.112")
+
+  // Defined in https://www.rfc-editor.org/rfc/rfc5758
+  // Registry http://oid-info.com/cgi-bin/display?oid=1.2.840.10045.4.3.2&a=display
+  object ECDSASha256AlgorithmIdentifier: TrifleAlgorithmIdentifier(oid = "1.2.840.10045.4.3.2")
 
   // Defined in https://datatracker.ietf.org/doc/html/draft-josefsson-pkix-newcurves-01
   // Registry http://oid-info.com/cgi-bin/display?oid=1.3.6.1.4.1.11591.15.1&a=display
-  object Ed25519AlgorithmIdentifier: TrifleAlgorithmIdentifier("1.3.6.1.4.1.11591.15.1")
+  object Ed25519AlgorithmIdentifier: TrifleAlgorithmIdentifier(oid = "1.3.6.1.4.1.11591.15.1")
 
   // Defined in https://www.rfc-editor.org/rfc/rfc5480
   // Registry http://oid-info.com/cgi-bin/display?oid=1.2.840.10045.3.1.7&a=display
-  object P256v1AlgorithmIdentifier: TrifleAlgorithmIdentifier("1.2.840.10045.3.1.7")
+  object P256v1AlgorithmIdentifier: TrifleAlgorithmIdentifier(oid = "1.2.840.10045.3.1.7")
 
   // Defined in https://www.rfc-editor.org/rfc/rfc3279
   // Registry http://oid-info.com/cgi-bin/display?oid=1.2.840.10045.2.1&a=display

--- a/jvm/src/main/kotlin/app/cash/security_sdk/internal/providers/BCContentVerifierProvider.kt
+++ b/jvm/src/main/kotlin/app/cash/security_sdk/internal/providers/BCContentVerifierProvider.kt
@@ -1,0 +1,39 @@
+package app.cash.security_sdk.internal.providers
+
+import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.operator.ContentVerifier
+import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder
+
+/**
+ * Internal trifle class to enable delegation to bouncycastle for signing with raw JCE keys.
+ */
+internal class BCContentVerifierProvider(
+  private val subjectPublicKeyInfo: SubjectPublicKeyInfo,
+) : TrifleContentVerifierProvider() {
+  private val delegateProvider by lazy {
+    JcaContentVerifierProviderBuilder()
+      .setProvider(BouncyCastleProvider())
+      .build(subjectPublicKeyInfo)
+  }
+
+  override fun get(algorithmIdentifer: AlgorithmIdentifier): ContentVerifier {
+    if (algorithmIdentifer != ECDSASha256AlgorithmIdentifier) {
+      throw UnsupportedOperationException(
+        "Unknown/unsupported AlgorithmId provided to obtain Trifle ContentVerifier"
+      )
+    }
+    return delegateProvider.get(algorithmIdentifer)
+  }
+
+  override fun getAssociatedCertificate(): X509CertificateHolder? {
+    return null
+  }
+
+  override fun hasAssociatedCertificate(): Boolean {
+    return false
+  }
+}

--- a/jvm/src/main/kotlin/app/cash/security_sdk/internal/providers/TinkContentVerifierProvider.kt
+++ b/jvm/src/main/kotlin/app/cash/security_sdk/internal/providers/TinkContentVerifierProvider.kt
@@ -33,7 +33,7 @@ internal class TinkContentVerifierProvider(
     // the algorithm passed-in matches our expected Tink algorithm ID.
     if (algorithmIdentifer != tinkAlgorithmIdentifier) {
       throw UnsupportedOperationException(
-        "Unknown/unsupported AlgorithmId provided to obtain S2DK ContentVerifier"
+        "Unknown/unsupported AlgorithmId provided to obtain Trifle ContentVerifier"
       )
     }
 

--- a/jvm/src/test/kotlin/app/cash/security_sdk/CertificateUtilTest.kt
+++ b/jvm/src/test/kotlin/app/cash/security_sdk/CertificateUtilTest.kt
@@ -1,6 +1,5 @@
 package app.cash.security_sdk
 
-import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier
 import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.Ed25519AlgorithmIdentifier
 import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.P256v1AlgorithmIdentifier
 import app.cash.security_sdk.internal.providers.TinkContentVerifierProvider

--- a/jvm/src/test/kotlin/app/cash/security_sdk/internal/providers/BCContentVerifierProviderTest.kt
+++ b/jvm/src/test/kotlin/app/cash/security_sdk/internal/providers/BCContentVerifierProviderTest.kt
@@ -1,0 +1,52 @@
+package app.cash.security_sdk.internal.providers
+
+import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
+import com.google.crypto.tink.signature.SignatureConfig
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.Signature
+import java.security.spec.ECGenParameterSpec
+
+internal class BCContentVerifierProviderTest {
+  private val data = byteArrayOf(0x00, 0x01, 0x02, 0x03)
+  private lateinit var privateSignKey: PrivateKey
+  private lateinit var contentVerifierProvider: BCContentVerifierProvider
+
+  @BeforeEach
+  fun setUp() {
+    SignatureConfig.register()
+    val ecSpec = ECGenParameterSpec("secp256r1")
+    val generator = KeyPairGenerator.getInstance("EC")
+    generator.initialize(ecSpec, SecureRandom())
+
+    val keypair: KeyPair = generator.generateKeyPair()
+    privateSignKey = keypair.private
+
+    contentVerifierProvider = BCContentVerifierProvider(
+      SubjectPublicKeyInfo.getInstance(keypair.public.encoded)
+    )
+  }
+
+  @Test
+  fun `test get() returns content verifier with appropriate key`() {
+    val bcContentVerifier = contentVerifierProvider.get(ECDSASha256AlgorithmIdentifier)
+    bcContentVerifier.outputStream.write(data)
+
+    val signature = Signature.getInstance("SHA256withECDSA")
+    signature.initSign(privateSignKey)
+    signature.update(data)
+
+    Assertions.assertTrue(bcContentVerifier.verify(signature.sign()))
+  }
+
+  @Test
+  fun `test getAssociatedCertificate`() {
+    Assertions.assertNull(contentVerifierProvider.associatedCertificate)
+  }
+}

--- a/jvm/src/test/kotlin/app/cash/security_sdk/internal/providers/TinkContentVerifierProviderTest.kt
+++ b/jvm/src/test/kotlin/app/cash/security_sdk/internal/providers/TinkContentVerifierProviderTest.kt
@@ -1,6 +1,5 @@
 package app.cash.security_sdk.internal.providers
 
-import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier
 import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.Ed25519AlgorithmIdentifier
 import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.TinkAlgorithmIdentifier
 import app.cash.security_sdk.internal.util.toSubjectPublicKeyInfo

--- a/jvm/src/test/kotlin/app/cash/security_sdk/internal/util/TinkUtil.kt
+++ b/jvm/src/test/kotlin/app/cash/security_sdk/internal/util/TinkUtil.kt
@@ -2,7 +2,6 @@ package app.cash.security_sdk.internal.util
 
 import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier
 import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.ECPublicKeyAlgorithmIdentifier
-import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.Ed25519AlgorithmIdentifier
 import com.google.crypto.tink.BinaryKeysetWriter
 import com.google.crypto.tink.CleartextKeysetHandle
 import com.google.crypto.tink.KeysetHandle


### PR DESCRIPTION
## Description
A parallel implementation of `ContentVerifierProvider` that handles raw key types instead of Tink wrapped keyset handles . The provider uses BouncyCastle as a delegate provider. 