### PR TITLE
Remove SNAPSHOT from 0.1.1 release.

### DIFF
--- a/android/cash-security-s2dk/src/test/java/app/cash/security_sdk/LibraryVersionUnitTest.kt
+++ b/android/cash-security-s2dk/src/test/java/app/cash/security_sdk/LibraryVersionUnitTest.kt
@@ -9,7 +9,7 @@ internal class LibraryVersionUnitTest {
     val libraryVersion = LibraryVersion()
     val versionString = libraryVersion.complete()
 
-    assertEquals(versionString, "0.1.1-SNAPSHOT")
+    assertEquals(versionString, "0.1.1")
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
-VERSION_NAME=0.1.1-SNAPSHOT
+VERSION_NAME=0.1.1
 VERSION_CODE=0


### PR DESCRIPTION
This should kick off publication of the 0.1.1 release of the library, enabling clients to use recently added features. Library is still very much 'in development' (v0) and all APIs are subject to change in future versions.