### PR TITLE
Begin development on 0.1.2.

### DIFF
--- a/android/cash-security-s2dk/src/test/java/app/cash/security_sdk/LibraryVersionUnitTest.kt
+++ b/android/cash-security-s2dk/src/test/java/app/cash/security_sdk/LibraryVersionUnitTest.kt
@@ -9,7 +9,7 @@ internal class LibraryVersionUnitTest {
     val libraryVersion = LibraryVersion()
     val versionString = libraryVersion.complete()
 
-    assertEquals(versionString, "0.1.1")
+    assertEquals(versionString, "0.1.2-SNAPSHOT")
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
-VERSION_NAME=0.1.1
+VERSION_NAME=0.1.2-SNAPSHOT
 VERSION_CODE=0

--- a/jvm/src/main/kotlin/app/cash/s2dk/common/LibraryVersion.kt
+++ b/jvm/src/main/kotlin/app/cash/s2dk/common/LibraryVersion.kt
@@ -3,7 +3,7 @@ package app.cash.s2dk.common
 class LibraryVersion : Version {
 
   // TODO(dcashman): Get this value from the gradle build setup.
-  private val recordedVersion: String = "0.1.1"
+  private val recordedVersion: String = "0.1.2"
 
   override fun complete(): String = recordedVersion
 

--- a/jvm/src/test/kotlin/app/cash/s2dk/common/LibraryVersionTest.kt
+++ b/jvm/src/test/kotlin/app/cash/s2dk/common/LibraryVersionTest.kt
@@ -9,7 +9,7 @@ internal class LibraryVersionUnitTest {
     val libraryVersion = LibraryVersion()
     val versionString = libraryVersion.complete()
 
-    assertEquals(versionString, "0.1.1")
+    assertEquals(versionString, "0.1.2")
   }
 
   @Test


### PR DESCRIPTION
Update version number to next version following the 0.1.1 release, and make sure that the version is -SNAPSHOT to prevent its publishing to maven.