### PR TITLE
Add priority property to ASN1Type for sorting

### DIFF
--- a/ios/SecuritySdk/Classes/ASN.1/ASN1Attribute.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1Attribute.swift
@@ -8,11 +8,12 @@ import Foundation
 /// ASN.1 constructed Attribute type, which is a tuple of the
 /// Object Identifer as the key and a collection of `ASN1Type`
 /// as its value, with DER (Distingushed Encoding Rules) encodable
-struct ASN1Attribute: ASN1Type {
+public struct ASN1Attribute: ASN1Type {
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
@@ -21,10 +22,12 @@ struct ASN1Attribute: ASN1Type {
         _ attributeSetValue: Array<ASN1Type>,
         _ type: Type = Type.none
     ) throws {
-        self.octets = try ASN1Sequence([
+        let seq = try ASN1Sequence([
             try ASN1ObjectIdentifier(oid),
             try ASN1Set(attributeSetValue)
-        ]).octets
+        ], type)
+        self.octets = seq.octets
+        self.priority = seq.priority
         self.tag = octets.first!
     }
 }

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1AttributeTypeValue.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1AttributeTypeValue.swift
@@ -8,11 +8,12 @@ import Foundation
 /// ASN.1 constructed Attribute Type Value type, which is a tuple of the
 /// Object Identifer as the key and a `ASN1Type` as the value,
 /// with DER (Distingushed Encoding Rules) encodable
-struct ASN1AttributeTypeValue: ASN1Type {
+public struct ASN1AttributeTypeValue: ASN1Type {
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
@@ -21,10 +22,12 @@ struct ASN1AttributeTypeValue: ASN1Type {
         _ value: ASN1Type,
         _ type: Type = Type.none
     ) throws {
-        self.octets = try ASN1Sequence([
+        let seq = try ASN1Sequence([
             try ASN1ObjectIdentifier(oid),
             value
-        ]).octets
+        ], type)
+        self.octets = seq.octets
+        self.priority = seq.priority
         self.tag = octets.first!
     }
 }

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1BitString.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1BitString.swift
@@ -7,17 +7,18 @@ import Foundation
 
 /// ASN.1 BitString with DER (Distingushed Encoding Rules) encodable
 public struct ASN1BitString: ASN1Type, DEREncodable {
-    public typealias T = Data
+    typealias T = Data
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
     public init(_ rawValue: Data, _ type: Type = Type.none, ignorePadding: Bool = false) throws {
-        self.octets = try Self.encode(rawValue, .bitString(type, ignorePadding))
+        (self.octets, self.priority) = try Self.encode(rawValue, .bitString(type, ignorePadding))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1Boolean.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1Boolean.swift
@@ -7,17 +7,18 @@ import Foundation
 
 /// ASN.1 Boolean with DER (Distingushed Encoding Rules) encodable
 public struct ASN1Boolean: ASN1Type, DEREncodable {
-    public typealias T = Bool
+    typealias T = Bool
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
     public init(_ rawValue: Bool, _ type: Type = Type.none) throws {
-        self.octets = try Self.encode(rawValue, .boolean(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .boolean(type))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1IA5String.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1IA5String.swift
@@ -7,17 +7,18 @@ import Foundation
 
 /// ASN.1 IA5String with DER (Distingushed Encoding Rules) encodable
 public struct ASN1IA5String: ASN1Type, DEREncodable {
-    public typealias T = String
+    typealias T = String
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
     public init(_ rawValue: String, _ type: Type = Type.none) throws {
-        self.octets = try Self.encode(rawValue, .ia5String(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .ia5String(type))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1Integer.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1Integer.swift
@@ -7,17 +7,18 @@ import Foundation
 
 /// ASN.1 Integer with DER (Distingushed Encoding Rules) encodable
 public struct ASN1Integer: ASN1Type, DEREncodable {
-    public typealias T = Int64
+    typealias T = Int64
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
     public init(_ rawValue: Int64, _ type: Type = Type.none) throws {
-        self.octets = try Self.encode(rawValue, .integer(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .integer(type))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1Null.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1Null.swift
@@ -7,17 +7,18 @@ import Foundation
 
 /// ASN.1 Null with DER (Distingushed Encoding Rules) encodable
 public struct ASN1Null: ASN1Type, DEREncodable {
-    public typealias T = Any?
+    typealias T = Any?
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
     public init(_ type: Type = Type.none) throws {
-        self.octets = try Self.encode(nil, .null(type))
+        (self.octets, self.priority) = try Self.encode(nil, .null(type))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1ObjectIdentifier.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1ObjectIdentifier.swift
@@ -7,12 +7,13 @@ import Foundation
 
 /// ASN.1 ObjectIdentifier with DER (Distingushed Encoding Rules) encodable
 public struct ASN1ObjectIdentifier: ASN1Type, DEREncodable {
-    public typealias T = [UInt]
+    typealias T = [UInt]
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
@@ -39,7 +40,7 @@ public struct ASN1ObjectIdentifier: ASN1Type, DEREncodable {
             )
         }
         
-        self.octets = try Self.encode(rawValue, .objectIdentifier(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .objectIdentifier(type))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1OctetString.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1OctetString.swift
@@ -7,17 +7,18 @@ import Foundation
 
 /// ASN.1 OctetString with DER (Distingushed Encoding Rules) encodable
 public struct ASN1OctetString: ASN1Type, DEREncodable {
-    public typealias T = Data
+    typealias T = Data
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
     public init(_ rawValue: Data, _ type: Type = Type.none) throws {
-        self.octets = try Self.encode(rawValue, .octetString(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .octetString(type))
         self.tag = octets.first!
     }
     

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1PrintableString.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1PrintableString.swift
@@ -7,12 +7,13 @@ import Foundation
 
 /// ASN.1 PrintableString with DER (Distingushed Encoding Rules) encodable
 public struct ASN1PrintableString: ASN1Type, DEREncodable {
-    public typealias T = String
+    typealias T = String
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
 
     // MARK: - Initialization
     
@@ -26,7 +27,7 @@ public struct ASN1PrintableString: ASN1Type, DEREncodable {
             throw DEREncodableError.invalidInput("Illegal character(s) present")
         }
 
-        self.octets = try Self.encode(rawValue, .printableString(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .printableString(type))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1Sequence.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1Sequence.swift
@@ -7,17 +7,18 @@ import Foundation
 
 /// ASN.1 Sequence with DER (Distingushed Encoding Rules) encodable
 public struct ASN1Sequence: ASN1Type, DEREncodable {
-    public typealias T = [any ASN1Type]
+    typealias T = [any ASN1Type]
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
     public init(_ rawValue: [any ASN1Type], _ type: Type = Type.none) throws {
-        self.octets = try Self.encode(rawValue, .sequence(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .sequence(type))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1Set.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1Set.swift
@@ -6,24 +6,27 @@
 import Foundation
 
 /// ASN.1 Set with DER (Distingushed Encoding Rules) encodable
-public struct ASN1Set: ASN1Type, DEREncodable {
-    public typealias T = [any ASN1Type]
+public struct ASN1Set: ASN1Type, DEREncodable {    
+    typealias T = [any ASN1Type]
 
     // MARK: - Public Properties
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
     
     // MARK: - Initialization
     
     public init(_ rawValue: [any ASN1Type], _ type: Type = Type.none) throws {
-        self.octets = try Self.encode(rawValue, .set(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .set(type))
         self.tag = octets.first!
     }
 
     // MARK: - Internal static methods (DEREncodable)
 
     internal static func encodeValue(_ rawValue: [any ASN1Type], _ tag: Tag) -> [Octet] {
-        return rawValue.sorted(by: { $0.tag < $1.tag }).flatMap { $0.octets }
+        return rawValue.sorted(by: {
+            $0.tag < $1.tag || $0.priority < $1.priority
+        }).flatMap { $0.octets }
     }
 }

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1Type.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1Type.swift
@@ -13,6 +13,8 @@ public protocol ASN1Type {
     var tag: Octet { get }
     /// tag-length-value octets
     var octets: [Octet] { get }
+    /// sort priority based on the value octet
+    var priority: Int { get }
 }
 
 // MARK: - Type

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1UTCTime.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1UTCTime.swift
@@ -13,11 +13,12 @@ public struct ASN1UTCTime: ASN1Type, DEREncodable {
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
 
     // MARK: - Initialization
     
     public init(_ rawValue: Date, _ type: Type = Type.none) throws {
-        self.octets = try Self.encode(rawValue, .utcTime(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .utcTime(type))
         self.tag = octets.first!
     }
 

--- a/ios/SecuritySdk/Classes/ASN.1/ASN1UTF8String.swift
+++ b/ios/SecuritySdk/Classes/ASN.1/ASN1UTF8String.swift
@@ -13,11 +13,12 @@ public struct ASN1UTF8String: ASN1Type, DEREncodable {
 
     public let tag: Octet
     public let octets: [Octet]
+    public let priority: Int
 
     // MARK: - Initialization
     
     public init(_ rawValue: String, _ type: Type = Type.none) throws {
-        self.octets = try Self.encode(rawValue, .utf8String(type))
+        (self.octets, self.priority) = try Self.encode(rawValue, .utf8String(type))
         self.tag = octets.first!
     }
     


### PR DESCRIPTION
## Description
This PR introduces a sort priority to each implementing ASN.1 type. This is necessary when a tiebreaker is needed when the tag type is not sufficient. The value octets are instead used for comparison. However, this only applies to primitive types, when an ASN.1 type happens to be constructed (set and sequence), the priority is calculated as a sum of the priorities of its collection.

----

In reference to X.690:
```
11.6 Set-of components
The encodings of the component values of a set-of value shall appear in ascending order, the encodings being compared
as octet strings with the shorter components being padded at their trailing end with 0-octets. 
```
https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf