### PR TITLE
Add test fixture for pkcs10 csr with raw key

### DIFF
--- a/jvm/src/main/kotlin/app/cash/security_sdk/CertificateUtil.kt
+++ b/jvm/src/main/kotlin/app/cash/security_sdk/CertificateUtil.kt
@@ -105,7 +105,7 @@ object CertificateUtil {
   }
 
   /**
-   * Create a mobile signing certificate request from a Tink signing keyset.
+   * Create a mobile signing certificate request with a Trifle Content Signer.
    *
    * @param entityName the name with which we'll associate the public key.
    * @param contentSigner content signer used to generate the signature validating the

--- a/jvm/src/test/kotlin/app/cash/security_sdk/internal/providers/BCContentVerifierProviderTest.kt
+++ b/jvm/src/test/kotlin/app/cash/security_sdk/internal/providers/BCContentVerifierProviderTest.kt
@@ -1,11 +1,17 @@
 package app.cash.security_sdk.internal.providers
 
+import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier
 import app.cash.security_sdk.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
+import app.cash.security_sdk.internal.util.TestFixtures
+import app.cash.security_sdk.internal.util.toSubjectPublicKeyInfo
 import com.google.crypto.tink.signature.SignatureConfig
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.pkcs.PKCS10CertificationRequest
+import org.bouncycastle.pkcs.PKCSException
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.PrivateKey
@@ -43,6 +49,20 @@ internal class BCContentVerifierProviderTest {
     signature.update(data)
 
     Assertions.assertTrue(bcContentVerifier.verify(signature.sign()))
+  }
+
+  @Test
+  fun `test iOS PKCS10 Certificate Request signature validation`() {
+    val pkcs10CertificateRequest = PKCS10CertificationRequest(TestFixtures.PKCS10Request)
+
+    // Make sure that the pkcs10 request is signature is validated
+    Assertions.assertTrue(
+      pkcs10CertificateRequest.isSignatureValid(
+        BCContentVerifierProvider(
+          pkcs10CertificateRequest.subjectPublicKeyInfo
+        )
+      )
+    )
   }
 
   @Test

--- a/jvm/src/test/kotlin/app/cash/security_sdk/internal/util/TestUtil.kt
+++ b/jvm/src/test/kotlin/app/cash/security_sdk/internal/util/TestUtil.kt
@@ -7,6 +7,7 @@ import com.google.crypto.tink.CleartextKeysetHandle
 import com.google.crypto.tink.KeysetHandle
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import java.io.ByteArrayOutputStream
+import java.util.Base64
 
 fun KeysetHandle.toSubjectPublicKeyInfo(curve: TrifleAlgorithmIdentifier): SubjectPublicKeyInfo {
   val outputStream = ByteArrayOutputStream()
@@ -18,5 +19,21 @@ fun KeysetHandle.toSubjectPublicKeyInfo(curve: TrifleAlgorithmIdentifier): Subje
   return SubjectPublicKeyInfo(
     ECPublicKeyAlgorithmIdentifier(curve),
     outputStream.toByteArray()
+  )
+}
+
+internal object TestFixtures {
+  // A PKCS#10 Certificate Request (PEM without the header and footer)
+  // generated from the iOS SDK.
+  val PKCS10Request: ByteArray = Base64.getDecoder().decode(
+    """
+    MIIBHjCBxAIBADBHMUUwCQYDVQQGEwJVUzAPBgNVBAMTCGNhc2guYXBwMBEGA1UE
+    CBMKQ2FsaWZvcm5pYTAUBgNVBAcTDVNhbiBGcmFuY2lzY28wWTATBgcqhkjOPQIB
+    BggqhkjOPQMBBwNCAAQNkp7f37RmuWxmybKevG8sCxu7tam07HDZuKpw35l41llH
+    39mgNDsNZ9xgK87Ix5q1WGIWbsKLsEjdvpg/d8uboBswGQYJKoZIhvcNAQkHMQwW
+    CmhlbGxvd29ybGQwCgYIKoZIzj0EAwIDSQAwRgIhAJ3KaP7tghkQz9cbOhjBbhsO
+    o4LRj3nIy5bhctwKTlNcAiEAw4LV2zc4lembWpFQk1f2d9ukLjkaVSAoSbviVdpf
+    e70=
+    """.filterNot { it.isWhitespace() }
   )
 }


### PR DESCRIPTION
## Description
This adds a test fixture for a PKCS10 csr generated with a raw p256 public key. The PR also adds a unit test to exercise the signature validation on both the CSR and the signed Certificate with a tink content signer.