### PR TITLE
Add unit tests in iOS for certificate decodability generated by JVM code

### DIFF
--- a/ios/Example/SecuritySdk.xcodeproj/project.pbxproj
+++ b/ios/Example/SecuritySdk.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		ACB0006DC5CF79D82C70294C /* Pods_SecuritySdk_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3C8548A7560DC459BC9C9FE /* Pods_SecuritySdk_Tests.framework */; };
+		E103FF9B29AD90F5004011C2 /* CertificateDecodableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E103FF9A29AD90F5004011C2 /* CertificateDecodableTest.swift */; };
 		E10D7FCC299410D0002E6B72 /* DEREncodableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10D7FCB299410D0002E6B72 /* DEREncodableTest.swift */; };
 		E1777ED829A0AE6900E5AC74 /* PKCS10CertificationRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1777ED729A0AE6900E5AC74 /* PKCS10CertificationRequestTests.swift */; };
 		E17B12F229882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17B12F129882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift */; };
@@ -48,6 +49,7 @@
 		B3C8548A7560DC459BC9C9FE /* Pods_SecuritySdk_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SecuritySdk_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D10EEC24DA7D67721BDB8A54 /* Pods_SecuritySdk_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SecuritySdk_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7107585B17135B120BF57AD /* Pods-SecuritySdk_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SecuritySdk_Tests.release.xcconfig"; path = "Target Support Files/Pods-SecuritySdk_Tests/Pods-SecuritySdk_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		E103FF9A29AD90F5004011C2 /* CertificateDecodableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateDecodableTest.swift; sourceTree = "<group>"; };
 		E10D7FCB299410D0002E6B72 /* DEREncodableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DEREncodableTest.swift; sourceTree = "<group>"; };
 		E1777ED729A0AE6900E5AC74 /* PKCS10CertificationRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCS10CertificationRequestTests.swift; sourceTree = "<group>"; };
 		E17B12F129882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureEnclaveDigitalSignatureKeyManagerTests.swift; sourceTree = "<group>"; };
@@ -128,6 +130,7 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E103FF9A29AD90F5004011C2 /* CertificateDecodableTest.swift */,
 				E10D7FCB299410D0002E6B72 /* DEREncodableTest.swift */,
 				E1777ED729A0AE6900E5AC74 /* PKCS10CertificationRequestTests.swift */,
 				E17B12F129882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift */,
@@ -351,6 +354,7 @@
 				E10D7FCC299410D0002E6B72 /* DEREncodableTest.swift in Sources */,
 				E17B12F229882D6100063394 /* SecureEnclaveDigitalSignatureKeyManagerTests.swift in Sources */,
 				E1777ED829A0AE6900E5AC74 /* PKCS10CertificationRequestTests.swift in Sources */,
+				E103FF9B29AD90F5004011C2 /* CertificateDecodableTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Example/Tests/CertificateDecodableTest.swift
+++ b/ios/Example/Tests/CertificateDecodableTest.swift
@@ -1,0 +1,49 @@
+//
+//  CertificateDecodableTest.swift
+//  SecuritySdk_Tests
+//
+
+import Foundation
+import SecuritySdk
+import XCTest
+
+final class CertificateDecodableTest: XCTestCase {
+    /// signed device certificate signed by JVM SDK
+    /// and CSR from iOS SDK
+    func testDecodesDeviceSignedCertificate() throws {
+        let derEncodedCert = Data(base64Encoded: """
+MIIBRDCB8qADAgECAgYBhpWf8vowBQYDK2VwMBgxFjAUBgNVBAMM\
+DWlzc3VpbmdFbnRpdHkwHhcNMjMwMjI4MDEyNTMzWhcNMjMwODI3\
+MDEyNTMzWjBHMUUwCQYDVQQGEwJVUzAPBgNVBAMTCGNhc2guYXBw\
+MBEGA1UECBMKQ2FsaWZvcm5pYTAUBgNVBAcTDVNhbiBGcmFuY2lz\
+Y28wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQNkp7f37RmuWxm\
+ybKevG8sCxu7tam07HDZuKpw35l41llH39mgNDsNZ9xgK87Ix5q1\
+WGIWbsKLsEjdvpg/d8ubMAUGAytlcANGAAEmroDFGvkG0JQJN+Er\
+g3IS3nzRtc3AqS/J/sr5xN3uU/wtaLewynZy2GO6SCfr/zfAY0ok\
+VicuTchtwvoEIq0lXZiJDQ==
+""")!
+        
+        let certificate = SecCertificateCreateWithData(nil, derEncodedCert as CFData)!
+        
+        XCTAssertEqual((SecCertificateCopySubjectSummary(certificate) as? String)!, "cash.app")
+    }
+    
+    func testDecodesIssuerCertificate() throws {
+        /// self-signed issuer certificate generated from JVM SDK
+        let derEncodedCert = Data(base64Encoded: """
+MIIBRjCB9KADAgECAgEBMAUGAytlcDAYMRYwFAYDVQQDDA1pc3N1\
+aW5nRW50aXR5MB4XDTIzMDIyODAxMjUzMloXDTIzMDMwMTAxMjUz\
+MlowGDEWMBQGA1UEAwwNaXNzdWluZ0VudGl0eTCBjjAWBgcqhkjO\
+PQIBMAsGCSsGAQQB2kcPAQN0AAjFgbq1AhJrCl8KN3R5cGUuZ29v\
+Z2xlYXBpcy5jb20vZ29vZ2xlLmNyeXB0by50aW5rLkVkMjU1MTlQ\
+dWJsaWNLZXkSIhIge1OAR3AF7czQTa5vto8gY/ZOnPm8Brnm/RJ+\
+I+BvCsoYAxABGMWBurUCIAEwBQYDK2VwA0YAASaugMW9V51Bt4az\
+BPdFheJaVnONFx1ybDViog7qFBL4uTybofiVd8wGwxXhtv9+LDZy\
+hjqHInJkLUH6UpcrHBd3ThAM
+""")!
+        
+        let certificate = SecCertificateCreateWithData(nil, derEncodedCert as CFData)!
+        
+        XCTAssertEqual((SecCertificateCopySubjectSummary(certificate) as? String)!, "issuingEntity")
+    }
+}


### PR DESCRIPTION
## Description
This PR adds unit tests in the iOS SDK to add confidence in the decodability of the certificates (issuer and device) from the JVM SDK.