### PR TITLE
Implement verifyCertificate in iOS

### DIFF
--- a/ios/Example/Tests/TrifleTests.swift
+++ b/ios/Example/Tests/TrifleTests.swift
@@ -43,4 +43,61 @@ final class TrifleTests: XCTestCase {
         XCTAssertEqual(mobileCertReq.version, 0)
         XCTAssertNotNil(mobileCertReq.pkcs10_request)
     }
+    
+    func testVerifyCertificate_succeeds() throws {
+        let trifle = try Trifle(tag: tag)
+        let mobileCertReq = try trifle.generateMobileCertificateRequest()
+
+        let deviceCertEncoded = Data(base64Encoded: """
+MIIBGTCBwaADAgECAgYBht0eNMMwCgYIKoZIzj0EAwIwGDEWMBQGA1UEAwwNaXNzdWluZ0VudGl0eTAeFw0yMzAzMTMyMjM2MjlaFw0yMzA5MDkyMjM2MjlaMBExDzANBgNVBAMMBmVudGl0eTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABICead8cmQi2cyHHTx316w9Q64L11U86PV3RK1IDsm/xiDoa5sbShjFPm0nhd+AFoTPtsXL6SJ/bt+sndXQL5gcwCgYIKoZIzj0EAwIDRwAwRAIgBQLsaQZpa93v33J/kSIxcl2UtBPCyYYDKahIGLy7xM4CIGeiGFjglmmaiqFf30esHdL4yR0/rbkVm4h6z9O+Rjfp
+""")!
+        
+        let rootCertEncoded = Data(base64Encoded: """
+MIIBZTCCAQqgAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDDA1pc3N1aW5nRW50aXR5MB4XDTIzMDMxMzIyMzUzMloXDTIzMDkwOTIyMzUzMlowGDEWMBQGA1UEAwwNaXNzdWluZ0VudGl0eTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABICead8cmQi2cyHHTx316w9Q64L11U86PV3RK1IDsm/xiDoa5sbShjFPm0nhd+AFoTPtsXL6SJ/bt+sndXQL5gejRTBDMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgIEMCAGA1UdDgEB/wQWBBQ/80Y00UVTlI6kiAZZ46kcrJ9a2jAKBggqhkjOPQQDAgNJADBGAiEAvffuwvImKNaolqnEr4ENB6LXEFdV0YVK3Ic3Mi+hqJ8CIQC7CiLwyvH1cChUReanIGeYiQp27LJ99M/qWLq6hmtSmQ==
+""")!
+        
+        let deviceCertificate = Certificate(version: 0, certificate: deviceCertEncoded)
+        let rootCertificate = Certificate(version: 0, certificate: rootCertEncoded)
+        let isVerified = deviceCertificate.verify(
+            certificateRequest: mobileCertReq,
+            certificateChain: [],
+            rootCertificate: rootCertificate
+        )
+        
+        XCTAssertTrue(isVerified)
+    }
+    
+    func testVerifyCertificate_fails() throws {
+        let trifle = try Trifle(tag: tag)
+        let mobileCertReq = try trifle.generateMobileCertificateRequest()
+
+        let deviceCertEncoded = Data(base64Encoded: """
+MIIBFDCBvKADAgECAgYBhtoH23kwCgYIKoZIzj0EAwIwEzERMA8GA1\
+UEAwwIY2FzaC5hcHAwHhcNMjMwMzEzMDgxMzEzWhcNMjMwOTA5MDgx\
+MzEzWjARMQ8wDQYDVQQDDAZlbnRpdHkwWTATBgcqhkjOPQIBBggqhk\
+jOPQMBBwNCAASGmNOZtRsOHr2XJVjL1jxRpeumY/jAF3rBDXhhbP49\
+5VYvMYkHfWjeNBzJ1YIqXLQf4BHdQQzDjSvT+abzpdjEMAoGCCqGSM\
+49BAMCA0cAMEQCIBXBwAm0Qn7S4vKRIHYLXDxhUQTqMuReoWBPfiOX\
+fREnAiByNBjSwVxp980/Nl17UvkBUNhTvp55CNuwMmlnporNNA==
+""")!
+
+        let otherRootCertEncoded = Data(base64Encoded: """
+MIHcMIGPoAMCAQICAQEwBQYDK2VwMBgxFjAUBgNVBAMMDWlzc3VpbmdFbnR\
+pdHkwHhcNMjMwMzEzMDYxMzI3WhcNMjMwMzE0MDYxMzI3WjAYMRYwFAYDVQ\
+QDDA1pc3N1aW5nRW50aXR5MCowBQYDK2VwAyEAm+Ac7932SHDPQLYd3p3gm\
+grcArUWrBqhPEC+q/QI3lEwBQYDK2VwA0EAJrfzN7qA3VqwazsT8yMIYMvY\
+Rz2iDA1898Yx5ELtlQcl7QUGXUmadwzW7rpxQB5wIk46tPTEJCFmUIYwrCB\
+4BQ==
+""")
+        
+        let deviceCertificate = Certificate(version: 0, certificate: deviceCertEncoded)
+        let otherRootCertificate = Certificate(version: 0, certificate: otherRootCertEncoded)
+        let isVerified = deviceCertificate.verify(
+            certificateRequest: mobileCertReq,
+            certificateChain: [],
+            rootCertificate: otherRootCertificate
+        )
+        
+        XCTAssertFalse(isVerified)
+    }
 }

--- a/ios/Trifle/Sources/Certificate/X509TrustManager.swift
+++ b/ios/Trifle/Sources/Certificate/X509TrustManager.swift
@@ -1,0 +1,36 @@
+//
+//  TrustManager.swift
+//  Trifle
+//
+
+import Foundation
+
+internal struct X509TrustManager {
+    
+    // MARK: - Internal Methods
+    
+    internal static func evaluate(_ certificates: Array<Certificate>) -> Bool {
+        let secCerts = certificates.map {
+            SecCertificateCreateWithData(nil, $0.certificate! as CFData)!
+        }
+        var optionalTrust: SecTrust?
+        let status = SecTrustCreateWithCertificates(
+            secCerts as AnyObject,
+            SecPolicyCreateBasicX509(),
+            &optionalTrust
+        )
+        
+        guard let trust = optionalTrust, status == errSecSuccess else {
+            return false
+        }
+
+        // sets the root certificate (tail of the array as the trust anchor
+        SecTrustSetAnchorCertificates(trust, [secCerts.last!] as CFArray)
+        // disables trusting any built-in anchors
+        SecTrustSetAnchorCertificatesOnly(trust, true)
+        // disables fetching from the network if missing intermediate chain(s)
+        SecTrustSetNetworkFetchAllowed(trust, false)
+        
+        return SecTrustEvaluateWithError(trust, nil)
+    }
+}

--- a/ios/Trifle/Sources/Trifle.swift
+++ b/ios/Trifle/Sources/Trifle.swift
@@ -86,10 +86,9 @@ extension Certificate {
     public func verify(
         certificateRequest: MobileCertificateRequest,
         certificateChain: Array<Certificate>,
-        rootCertificate: Certificate? = nil
+        rootCertificate: Certificate
     ) -> Bool {
-        // TODO: Implement
-        return true
+        return X509TrustManager.evaluate([self] + certificateChain + [rootCertificate])
     }
 }
 


### PR DESCRIPTION
## Description
This PR implements verifyCertificate in the iOS SDK to validate a given leaf (device certificate) against the certificate chain and up to the root certificate. 