### PR TITLE
Upgrade tink to 1.7.0

### DIFF
--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -57,7 +57,7 @@ repositories {
 dependencies {
     implementation("org.bouncycastle:bcprov-jdk15to18:1.70")
     implementation("org.bouncycastle:bcpkix-jdk15to18:1.70")
-    implementation("com.google.crypto.tink:tink:1.6.0")
+    api("com.google.crypto.tink:tink:1.7.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
 }
 

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/signers/TinkContentSigner.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/signers/TinkContentSigner.kt
@@ -12,7 +12,7 @@ import com.google.crypto.tink.proto.EllipticCurveType
 import com.google.crypto.tink.signature.SignatureConfig.ECDSA_PUBLIC_KEY_TYPE_URL
 import com.google.crypto.tink.signature.SignatureConfig.ED25519_PUBLIC_KEY_TYPE_URL
 import com.google.crypto.tink.tinkkey.KeyAccess
-import com.google.crypto.tink.tinkkey.ProtoKey
+import com.google.crypto.tink.tinkkey.internal.ProtoKey
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.jce.ECNamedCurveTable


### PR DESCRIPTION
## Description
This PR upgrades tink to 1.7.0 which has the package path of TinkKey changed. Dependencies on Trifle that also pulls in Tink may not be compatible due to the classpath not matching. By changing the gradle build script to compile the binary interface, we avoid runtime issues in the future