### PR TITLE
Add KeyHandle class for Android SDK.

### DIFF
--- a/android/sample_app/src/main/java/app/cash/trifle/MainActivity.kt
+++ b/android/sample_app/src/main/java/app/cash/trifle/MainActivity.kt
@@ -10,7 +10,11 @@ class MainActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     val version = LibraryVersion()
-    Log.v(TAG, "Security SDK version: $version")
+    Log.v(TAG, "Trifle version: $version")
+
+    //Example Trifle use.  Shouldn't typically be on the main UI thread, but that's the only reason
+    // we're here so it's ok.
+    val keyHandle = KeyHandle.generateKeyHandle("alias")
 
     setContentView(R.layout.activity_main)
   }

--- a/android/trifle/src/main/java/app/cash/trifle/KeyHandle.kt
+++ b/android/trifle/src/main/java/app/cash/trifle/KeyHandle.kt
@@ -1,0 +1,57 @@
+package app.cash.trifle
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Log
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.spec.ECGenParameterSpec
+
+data class KeyHandle internal constructor(private val alias: String) {
+  init {
+    val ks = KeyStore.getInstance(ANDROID_KEYSTORE_TYPE).apply {
+      load(null)
+    }
+    if (!ks.containsAlias(alias)) {
+      // Need to generate a new key for this key alias in the keystore.
+      val kpg: KeyPairGenerator = KeyPairGenerator.getInstance(
+        KeyProperties.KEY_ALGORITHM_EC,
+        ANDROID_KEYSTORE_TYPE
+      )
+      val parameterSpec: KeyGenParameterSpec = KeyGenParameterSpec.Builder(
+        alias,
+        KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY
+      ).run {
+        setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+        setUserAuthenticationRequired(false)
+        setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+        build()
+      }
+
+      kpg.initialize(parameterSpec)
+
+      val kp = kpg.generateKeyPair()
+      Log.i("TRIFLE", "Created KeyHandle with alias $alias")
+    }
+  }
+
+  fun serialize(): ByteArray = alias.toByteArray(Charsets.UTF_8)
+
+  companion object {
+    private const val ANDROID_KEYSTORE_TYPE: String = "AndroidKeyStore"
+
+    fun deserialize(bytes: ByteArray): KeyHandle {
+      val alias = bytes.toString(Charsets.UTF_8)
+      val ks = KeyStore.getInstance(ANDROID_KEYSTORE_TYPE)
+      if (!ks.containsAlias(alias)) {
+        throw IllegalArgumentException(
+          "Android KeyStore does not contain a keypair corresponding to the $alias alias")
+      }
+      return KeyHandle(alias)
+    }
+
+    fun generateKeyHandle(alias: String): KeyHandle {
+      return KeyHandle(alias)
+    }
+  }
+}

--- a/android/trifle/src/main/java/app/cash/trifle/KeyHandle.kt
+++ b/android/trifle/src/main/java/app/cash/trifle/KeyHandle.kt
@@ -7,7 +7,7 @@ import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.spec.ECGenParameterSpec
 
-data class KeyHandle internal constructor(private val alias: String) {
+class KeyHandle internal constructor(private val alias: String) {
   init {
     val ks = KeyStore.getInstance(ANDROID_KEYSTORE_TYPE).apply {
       load(null)
@@ -50,6 +50,7 @@ data class KeyHandle internal constructor(private val alias: String) {
       return KeyHandle(alias)
     }
 
+    //TODO(dcashman): Consoidate API surface with iOS surface.
     fun generateKeyHandle(alias: String): KeyHandle {
       return KeyHandle(alias)
     }


### PR DESCRIPTION
The KeyHandle class is responsible for abstracting away key generation and use. Add the class, and corresponding key generation.