### PR TITLE
Change android jvm gradle dependency to api from implementation.

### DIFF
--- a/android/trifle/build.gradle.kts
+++ b/android/trifle/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
   androidTestImplementation("androidx.test.ext:junit:1.1.5")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 
-  implementation(project(":jvm"))
+  api(project(":jvm"))
 }
 
 configure<com.vanniktech.maven.publish.MavenPublishBaseExtension> {


### PR DESCRIPTION
The jvm project contains APIs which should be common across Android and server Trifle use-cases.  Switching to api() enables them to be used directly on Android without needing a wrapper.