### PR TITLE
Add an instrumentation test for KeyHandle

### DIFF
--- a/android/trifle/build.gradle.kts
+++ b/android/trifle/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
   testImplementation("junit:junit:4.+")
   androidTestImplementation("androidx.test.ext:junit:1.1.5")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+  androidTestImplementation("com.google.truth:truth:1.1.3")
 
   api(project(":jvm"))
 }

--- a/android/trifle/src/androidTest/java/app/cash/trifle/KeyHandleTest.kt
+++ b/android/trifle/src/androidTest/java/app/cash/trifle/KeyHandleTest.kt
@@ -1,0 +1,12 @@
+package app.cash.trifle
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class KeyHandleTest {
+  @Test fun serializeDeserialize() {
+    val keyHandle = KeyHandle.generateKeyHandle("test-alias")
+    val serializedBytes = keyHandle.serialize()
+    assertThat(KeyHandle.deserialize(serializedBytes)).isEqualTo(keyHandle)
+  }
+}

--- a/android/trifle/src/main/java/app/cash/trifle/KeyHandle.kt
+++ b/android/trifle/src/main/java/app/cash/trifle/KeyHandle.kt
@@ -37,6 +37,13 @@ class KeyHandle internal constructor(private val alias: String) {
 
   fun serialize(): ByteArray = alias.toByteArray(Charsets.UTF_8)
 
+  override fun equals(other: Any?): Boolean {
+    val other = other as? KeyHandle ?: return false
+    return alias == other.alias
+  }
+
+  override fun hashCode(): Int = alias.hashCode()
+
   companion object {
     private const val ANDROID_KEYSTORE_TYPE: String = "AndroidKeyStore"
 


### PR DESCRIPTION
Currently fails with:

```
java.security.KeyStoreException: Uninitialized keystore
at java.security.KeyStore.containsAlias(KeyStore.java:1312)
at app.cash.trifle.KeyHandle$Companion.deserialize(KeyHandle.kt:53)
at app.cash.trifle.KeyHandleTest.serializeDeserialize(KeyHandleTest.kt:10)
```