### PR TITLE
Load params to keystore

### DIFF
--- a/android/sample_app/build.gradle.kts
+++ b/android/sample_app/build.gradle.kts
@@ -5,9 +5,8 @@ plugins {
 
 android {
   compileSdkVersion(33)
-  buildToolsVersion("30.0.2")
 
-  defaultConfig {
+    defaultConfig {
     applicationId = "app.cash.trifle"
     minSdkVersion(24)
     targetSdkVersion(33)

--- a/android/trifle/build.gradle.kts
+++ b/android/trifle/build.gradle.kts
@@ -7,9 +7,8 @@ plugins {
 
 android {
   compileSdkVersion(33)
-  buildToolsVersion("30.0.2")
 
-  defaultConfig {
+    defaultConfig {
     minSdkVersion(24)
     targetSdkVersion(33)
 

--- a/android/trifle/src/main/java/app/cash/trifle/KeyHandle.kt
+++ b/android/trifle/src/main/java/app/cash/trifle/KeyHandle.kt
@@ -42,7 +42,9 @@ class KeyHandle internal constructor(private val alias: String) {
 
     fun deserialize(bytes: ByteArray): KeyHandle {
       val alias = bytes.toString(Charsets.UTF_8)
-      val ks = KeyStore.getInstance(ANDROID_KEYSTORE_TYPE)
+      val ks = KeyStore.getInstance(ANDROID_KEYSTORE_TYPE).apply {
+        load(null)
+      }
       if (!ks.containsAlias(alias)) {
         throw IllegalArgumentException(
           "Android KeyStore does not contain a keypair corresponding to the $alias alias")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-android-gradle-plugin = { module = "com.android.tools.build:gradle", version = "7.3.1" }
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version = "7.4.2" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.20" }
 mavenPublish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.23.2" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "1.7.10" }


### PR DESCRIPTION
## Description
When deserializing, the instance of the keystore is instantiated but not initialized. In order to do so, the load function has to be called without any parameters. This will fix PR[#97](https://github.com/cashapp/trifle/pull/97).