### PR TITLE
disable network access for secTrustEvaluateWithError

### DIFF
--- a/ios/Trifle/Sources/Certificate/X509TrustManager.swift
+++ b/ios/Trifle/Sources/Certificate/X509TrustManager.swift
@@ -24,6 +24,9 @@ internal struct X509TrustManager {
             return false
         }
 
+        // Disable network access for SecTrustEvaluateWithError
+        SecTrustSetNetworkFetchAllowed(trust, false);
+
         // sets the root certificate (tail of the array as the trust anchor
         SecTrustSetAnchorCertificates(trust, [secCerts.last!] as CFArray)
         // disables trusting any built-in anchors


### PR DESCRIPTION
This allows certificate.verify and createSignedData to be called on the main thread.