### PR TITLE
Update gradle_build.yml

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout project sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Run build with Gradle Wrapper
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.repository == 'cashapp/trifle' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Checkout project sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Run build with Gradle Wrapper


### PR DESCRIPTION
Update `actions/checkout@v2` to `actions/checkout@v3` to support (node12 --> node16). 

According to error message
Node.js 12 actions are deprecated. 
Please update the following actions to use Node.js 16:  actions/checkout@v2. 

For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.