### PR TITLE
Update platform to macOS for publish job

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -15,7 +15,7 @@ jobs:
       run: ./gradlew build
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: ${{ github.repository == 'cashapp/trifle' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Checkout project sources


### PR DESCRIPTION
## Description
Hypothesis is that ubuntu-latest might be incompatible with action runner. Switching to macOS might resolve timeout issues: https://github.com/actions/runner-images/issues/6704