### PR TITLE
bump up iOS version to 0.2.1

### DIFF
--- a/Trifle.podspec
+++ b/Trifle.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Trifle'
-  s.version          = '0.2.0'
+  s.version          = '0.2.1'
   s.summary          = 'Security related functions.'
 
   s.description      = <<-DESC

--- a/ios/Trifle/Sources/Trifle.swift
+++ b/ios/Trifle/Sources/Trifle.swift
@@ -8,7 +8,7 @@ import Wire
 
 public class Trifle {
     
-    public static let version = "0.2.0"
+    public static let version = "0.2.1"
     
     private static let mobileCertificateRequestVersion = UInt32(0)
     


### PR DESCRIPTION
This version introduces new Trifle APIs for checking key handle validity and deleting a key handle from the key chain.