### PR TITLE
Swift: Fix warning in Xcode 14.3

### DIFF
--- a/ios/Trifle/Sources/Digital Signature/Secure Enclave/SecureEnclaveKeychainQueries.swift
+++ b/ios/Trifle/Sources/Digital Signature/Secure Enclave/SecureEnclaveKeychainQueries.swift
@@ -42,7 +42,7 @@ internal struct SecureEnclaveKeychainQueries: KeychainQueries {
                 kSecAttrIsPermanent: true,
                 kSecAttrApplicationTag: applicationTag.data(using: .utf8)!,
                 kSecAttrAccessControl: try Self.access,
-            ],
+            ] as [CFString: Any],
         ]
         
         #if !targetEnvironment(simulator)


### PR DESCRIPTION
Fixes this warning about inferred types:

> ios/Trifle/Sources/Digital Signature/Secure Enclave/SecureEnclaveKeychainQueries.swift:41:34: warning: heterogeneous collection literal could only be inferred to '[CFString : Any]'; add explicit type annotation if this is intentional
> 
>```
>             kSecPrivateKeyAttrs: [
> ```