### PR TITLE
Remove unnecessary dependencies from Android implementation

### DIFF
--- a/android/trifle/build.gradle.kts
+++ b/android/trifle/build.gradle.kts
@@ -36,9 +36,6 @@ android {
 }
 
 dependencies {
-  implementation("androidx.core:core-ktx:1.10.0")
-  implementation("androidx.appcompat:appcompat:1.6.1")
-  implementation("com.google.android.material:material:1.9.0")
   testImplementation("junit:junit:4.13.2")
   androidTestImplementation("androidx.test.ext:junit:1.1.5")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")


### PR DESCRIPTION
These dependencies are being included on projects that import Trifle, so we need to remove them.