### PR TITLE
Add authority key identifier extension

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
-android-gradle-plugin = { module = "com.android.tools.build:gradle", version = "7.4.0-beta02" }
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version = "7.4.2" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.7.20" }
 mavenPublish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.23.2" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "1.7.10" }


### PR DESCRIPTION
## Description
The authority key identifier extension field may be used by the issuer and end entity to identify a signing certificate chain which is recommended in [RFC 3280](https://www.rfc-editor.org/rfc/rfc3280#section-4.2.1.2). 

The certificate authority will have the same key identifier for both the authority and subject key identifier fields.

The end entity will have its public key's checksum as the value of the subject key identifier field, but the issuer's subject key identifier as the value of its authority key identifier field.

---

## Fix
Both the subject and authority key identifier fields should not be marked as critical