### PR TITLE
Add verify() method to the jvm certificate representation.

### DIFF
--- a/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
@@ -1,6 +1,11 @@
 package app.cash.trifle
 
+import app.cash.trifle.CertificateRequest.PKCS10Request
+import app.cash.trifle.internal.validators.CertChainValidatorFactory
 import okio.ByteString.Companion.toByteString
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import java.security.cert.X509Certificate
 import app.cash.trifle.protos.api.alpha.Certificate as CertificateProto
 
 /**
@@ -21,6 +26,40 @@ data class Certificate internal constructor(
       certificate = certificate.toByteString(),
       version = CERTIFICATE_VERSION
     ).encode()
+
+  /**
+   * Verify that the provided certificate matches what we expected.
+   * It matches the CSR that we have and the root cert is what
+   * we expect.
+   *
+   * @param certificateRequest -  request used to generate this certificate
+   * @param certificateChain - list of certificates with each subsequent certificate signing the one
+   *   before it, starting with the parent of this certificate.
+   * @return - false if certificate is not signed by the given root certificate, or if the
+   *   information present doesn't match that of the certificateRequest.
+   *   //TODO(dcashman): Return errors specific to each type of failure so clients can remediate.
+   */
+  fun verify(
+    certificateRequest: CertificateRequest,
+    certificateChain: List<Certificate>,
+    rootCertificate: Certificate
+  ): Boolean {
+    // First check to see if the certificate chain matches
+    val validator = CertChainValidatorFactory.get(rootCertificate)
+    if (!validator.validate(listOf(this) + certificateChain)) return false
+
+    // Certificate chain matches, check with certificate request.
+    // TODO(dcashman): Check other attributes as well.
+    val x509Certificate = X509CertificateHolder(certificate)
+    return when (certificateRequest) {
+      is PKCS10Request -> {
+        certificateRequest.pkcs10Req.subject.equals(x509Certificate.subject) && certificateRequest.pkcs10Req.subjectPublicKeyInfo.equals(
+          x509Certificate.subjectPublicKeyInfo
+        )
+      }
+      else -> false
+    }
+  }
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/jvm/src/test/kotlin/app/cash/trifle/CertificateTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/CertificateTests.kt
@@ -1,0 +1,52 @@
+package app.cash.trifle
+
+import app.cash.trifle.testing.TestCertificateAuthority
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import java.security.*
+
+internal class CertificateTests {
+  @Nested
+  @DisplayName("Certificate#verify() Tests")
+  inner class CertificateVerifyTests {
+    @Test
+    fun `test verify() returns true for a properly issued certificate`() {
+      assertTrue(
+        endEntity.certificate.verify(
+          endEntity.certRequest,
+          endEntity.certChain.drop(1),
+          certificateAuthority.rootCertificate
+        )
+      )
+    }
+
+    @Test
+    fun `test verify() fails for a legitimate certificate from the same CA, but wrong entity`() {
+      val otherEndEntity = certificateAuthority.createTestEndEntity("other_entity")
+      assertFalse(
+        endEntity.certificate.verify(
+          otherEndEntity.certRequest,
+          otherEndEntity.certChain.drop(1),
+          certificateAuthority.rootCertificate
+        )
+      )
+    }
+
+    @Test
+    fun `test verify() fails for a different root certificate`() {
+      val otherEndEntity = certificateAuthority.createTestEndEntity("other_entity")
+      assertFalse(
+        endEntity.certificate.verify(
+          endEntity.certRequest,
+          endEntity.certChain.drop(1),
+          TestCertificateAuthority("otherIssuingEntity").rootCertificate
+        )
+      )
+    }
+  }
+
+  companion object {
+    private val certificateAuthority = TestCertificateAuthority("issuingEntity")
+    private val endEntity = certificateAuthority.createTestEndEntity("entity")
+  }
+}

--- a/jvm/src/test/kotlin/app/cash/trifle/CertificateTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/CertificateTests.kt
@@ -34,7 +34,6 @@ internal class CertificateTests {
 
     @Test
     fun `test verify() fails for a different root certificate`() {
-      val otherEndEntity = certificateAuthority.createTestEndEntity("other_entity")
       assertFalse(
         endEntity.certificate.verify(
           endEntity.certRequest,


### PR DESCRIPTION
Check that the provided certificate matches the associated certificate chain and also that the certificate contains the same information as the passed-in certificate request.