### PR TITLE
Change Certificate.verify() to include reason in response.

### DIFF
--- a/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
@@ -81,14 +81,14 @@ data class Certificate internal constructor(
     // Certificate chain matches, check with certificate request.
     // TODO(dcashman): Check other attributes as well.
     val x509Certificate = X509CertificateHolder(certificate)
-    when (certificateRequest) {
+    return when (certificateRequest) {
       is PKCS10Request -> {
         if (certificateRequest.pkcs10Req.subject == x509Certificate.subject
           && certificateRequest.pkcs10Req.subjectPublicKeyInfo == x509Certificate.subjectPublicKeyInfo
         ) {
-          return VerifyResult(SUCCESS)
+          VerifyResult(SUCCESS)
         } else {
-          return VerifyResult(CSR_MISMATCH)
+          VerifyResult(CSR_MISMATCH)
         }
       }
     }

--- a/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
@@ -1,9 +1,17 @@
 package app.cash.trifle
 
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.CSR_MISMATCH
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.EXPIRED
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.INCORRECT_SIGNATURE
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.SUCCESS
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.UNSPECIFIED_FAILURE
 import app.cash.trifle.CertificateRequest.PKCS10Request
 import app.cash.trifle.internal.validators.CertChainValidatorFactory
 import okio.ByteString.Companion.toByteString
 import org.bouncycastle.cert.X509CertificateHolder
+import java.security.cert.CertPathValidatorException
+import java.security.cert.CertPathValidatorException.BasicReason
+import java.util.Date
 import app.cash.trifle.protos.api.alpha.Certificate as CertificateProto
 
 /**
@@ -37,30 +45,62 @@ data class Certificate internal constructor(
    * @param anchorCertificate - the trust anchor against which we would like to verify the
    *   ancestorCertificateChain. This may be the terminal (root) certificate of the chain or may be
    *   an intermediate certificate in the chain which is already trusted.
+   * @param date - The date to use for verification against certificates' validity windows. If null,
+   *   the current time is used.
    *
-   * @return - false if certificate is not signed by the given root certificate, or if the
-   *   information present doesn't match that of the certificateRequest.
-   *   //TODO(dcashman): Return errors specific to each type of failure so clients can remediate.
+   * @return - VerifyResult status indicating issue if certificate is not signed by the given root
+   *   certificate, or if the information present doesn't match that of the certificateRequest.
+   *   SUCCESS otherwise.
    */
   fun verify(
     certificateRequest: CertificateRequest,
     ancestorCertificateChain: List<Certificate>,
-    anchorCertificate: Certificate
-  ): Boolean {
+    anchorCertificate: Certificate,
+    date: Date?
+  ): VerifyResult {
     // First check to see if the certificate chain matches
-    val validator = CertChainValidatorFactory.get(anchorCertificate)
-    if (!validator.validate(listOf(this) + ancestorCertificateChain)) return false
+    val validator = CertChainValidatorFactory.get(anchorCertificate, date)
+    try {
+      if (!validator.validate(listOf(this) + ancestorCertificateChain)) return VerifyResult(
+        UNSPECIFIED_FAILURE
+      )
+    } catch (e: CertPathValidatorException) {
+      val reason = e.reason
+      if (reason is BasicReason) {
+        return when (reason) {
+          BasicReason.EXPIRED -> VerifyResult(EXPIRED, e.message ?: "")
+          BasicReason.INVALID_SIGNATURE -> VerifyResult(INCORRECT_SIGNATURE, e.message ?: "")
+          else -> VerifyResult(UNSPECIFIED_FAILURE, e.message ?: "")
+        }
+      }
+      return VerifyResult(UNSPECIFIED_FAILURE, e.message ?: "")
+    } catch (e: Exception) {
+      return VerifyResult(UNSPECIFIED_FAILURE, e.message ?: "")
+    }
 
     // Certificate chain matches, check with certificate request.
     // TODO(dcashman): Check other attributes as well.
     val x509Certificate = X509CertificateHolder(certificate)
-    return when (certificateRequest) {
+    when (certificateRequest) {
       is PKCS10Request -> {
-        certificateRequest.pkcs10Req.subject == x509Certificate.subject
+        if (certificateRequest.pkcs10Req.subject == x509Certificate.subject
           && certificateRequest.pkcs10Req.subjectPublicKeyInfo == x509Certificate.subjectPublicKeyInfo
+        ) {
+          return VerifyResult(SUCCESS)
+        } else {
+          return VerifyResult(CSR_MISMATCH)
+        }
       }
-      else -> false
     }
+    return VerifyResult(UNSPECIFIED_FAILURE)
+  }
+
+  fun verify(
+    certificateRequest: CertificateRequest,
+    ancestorCertificateChain: List<Certificate>,
+    anchorCertificate: Certificate,
+  ): VerifyResult {
+    return verify(certificateRequest, ancestorCertificateChain, anchorCertificate, null)
   }
 
   override fun equals(other: Any?): Boolean {
@@ -83,6 +123,37 @@ data class Certificate internal constructor(
 
   companion object {
     internal const val CERTIFICATE_VERSION: Int = 0
+
+    class VerifyResult constructor(val reason: Reason, val msg: String) {
+      constructor(reason: Reason) : this(reason, "")
+
+      override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as VerifyResult
+
+        return reason == other.reason && msg.equals(other.msg)
+      }
+
+      override fun hashCode(): Int {
+        var result = msg.hashCode()
+        result = 31 * result + reason.ordinal
+        return result
+      }
+
+      override fun toString(): String {
+        return "$reason $msg"
+      }
+
+      enum class Reason {
+        SUCCESS,
+        UNSPECIFIED_FAILURE,
+        EXPIRED,
+        INCORRECT_SIGNATURE,
+        CSR_MISMATCH
+      }
+    }
 
     /**
      * Create a Trifle Certificate from its binary representation, which is a serialized proto for

--- a/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
@@ -56,7 +56,7 @@ data class Certificate internal constructor(
     certificateRequest: CertificateRequest,
     ancestorCertificateChain: List<Certificate>,
     anchorCertificate: Certificate,
-    date: Date?
+    date: Date? = null
   ): VerifyResult {
     // First check to see if the certificate chain matches
     val validator = CertChainValidatorFactory.get(anchorCertificate, date)
@@ -68,14 +68,14 @@ data class Certificate internal constructor(
       val reason = e.reason
       if (reason is BasicReason) {
         return when (reason) {
-          BasicReason.EXPIRED -> VerifyResult(EXPIRED, e.message ?: "")
-          BasicReason.INVALID_SIGNATURE -> VerifyResult(INCORRECT_SIGNATURE, e.message ?: "")
-          else -> VerifyResult(UNSPECIFIED_FAILURE, e.message ?: "")
+          BasicReason.EXPIRED -> VerifyResult(EXPIRED, e.message)
+          BasicReason.INVALID_SIGNATURE -> VerifyResult(INCORRECT_SIGNATURE, e.message)
+          else -> VerifyResult(UNSPECIFIED_FAILURE, e.message)
         }
       }
-      return VerifyResult(UNSPECIFIED_FAILURE, e.message ?: "")
+      return VerifyResult(UNSPECIFIED_FAILURE, e.message)
     } catch (e: Exception) {
-      return VerifyResult(UNSPECIFIED_FAILURE, e.message ?: "")
+      return VerifyResult(UNSPECIFIED_FAILURE, e.message)
     }
 
     // Certificate chain matches, check with certificate request.
@@ -93,14 +93,6 @@ data class Certificate internal constructor(
       }
     }
     return VerifyResult(UNSPECIFIED_FAILURE)
-  }
-
-  fun verify(
-    certificateRequest: CertificateRequest,
-    ancestorCertificateChain: List<Certificate>,
-    anchorCertificate: Certificate,
-  ): VerifyResult {
-    return verify(certificateRequest, ancestorCertificateChain, anchorCertificate, null)
   }
 
   override fun equals(other: Any?): Boolean {
@@ -124,8 +116,7 @@ data class Certificate internal constructor(
   companion object {
     internal const val CERTIFICATE_VERSION: Int = 0
 
-    class VerifyResult constructor(val reason: Reason, val msg: String) {
-      constructor(reason: Reason) : this(reason, "")
+    class VerifyResult constructor(val reason: Reason, val msg: String? = "") {
 
       override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -143,7 +134,7 @@ data class Certificate internal constructor(
       }
 
       override fun toString(): String {
-        return "$reason $msg"
+        return "$reason ${msg.orEmpty()}"
       }
 
       enum class Reason {

--- a/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
@@ -116,22 +116,7 @@ data class Certificate internal constructor(
   companion object {
     internal const val CERTIFICATE_VERSION: Int = 0
 
-    class VerifyResult constructor(val reason: Reason, val msg: String? = "") {
-
-      override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as VerifyResult
-
-        return reason == other.reason && msg.equals(other.msg)
-      }
-
-      override fun hashCode(): Int {
-        var result = msg.hashCode()
-        result = 31 * result + reason.ordinal
-        return result
-      }
+    data class VerifyResult constructor(val reason: Reason, val msg: String? = "") {
 
       override fun toString(): String {
         return "$reason ${msg.orEmpty()}"

--- a/jvm/src/main/kotlin/app/cash/trifle/SignedData.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/SignedData.kt
@@ -22,7 +22,11 @@ data class SignedData internal constructor(
 ) {
   fun verify(certAnchor: Certificate): Boolean {
     val validator = CertChainValidatorFactory.get(certAnchor)
-    if (!validator.validate(certificates)) return false
+    try {
+      if (!validator.validate(certificates)) return false
+    } catch (e: Exception) {
+      return false
+    }
 
     val contentVerifier = JCAContentVerifierProvider(certificates.first())
       .get(envelopedData.signingAlgorithm)

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/validators/CertChainValidatorFactory.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/validators/CertChainValidatorFactory.kt
@@ -17,14 +17,10 @@ object CertChainValidatorFactory {
    * @param date - The date to use for verification against certificates' validity windows. If null,
    *   the current time is used.
    */
-  fun get(certAnchor: Certificate, date: Date?): CertChainValidator {
+  fun get(certAnchor: Certificate, date: Date? = null): CertChainValidator {
     return when (certAnchor.version) {
       CERTIFICATE_VERSION -> X509CertChainValidator(certAnchor, date)
       else -> throw UnsupportedOperationException("Unsupported version of Trifle Certificate")
     }
-  }
-
-  fun get(certAnchor: Certificate): CertChainValidator {
-    return get(certAnchor, null)
   }
 }

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/validators/CertChainValidatorFactory.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/validators/CertChainValidatorFactory.kt
@@ -2,16 +2,29 @@ package app.cash.trifle.internal.validators
 
 import app.cash.trifle.Certificate
 import app.cash.trifle.Certificate.Companion.CERTIFICATE_VERSION
+import java.util.Date
 
 /**
  * Factory class that determines a specific certificate chain validator from the certificate
  * anchor's version.
  */
 object CertChainValidatorFactory {
-  fun get(certAnchor: Certificate): CertChainValidator {
+
+  /**
+   * Return a certificate validator matching the provided certAnchor.
+   * @param certAnchor - The certificate to use as the root certificate in the certificate chain. Its
+   *   format will determine how verification should be performed.
+   * @param date - The date to use for verification against certificates' validity windows. If null,
+   *   the current time is used.
+   */
+  fun get(certAnchor: Certificate, date: Date?): CertChainValidator {
     return when (certAnchor.version) {
-      CERTIFICATE_VERSION -> X509CertChainValidator(certAnchor)
+      CERTIFICATE_VERSION -> X509CertChainValidator(certAnchor, date)
       else -> throw UnsupportedOperationException("Unsupported version of Trifle Certificate")
     }
+  }
+
+  fun get(certAnchor: Certificate): CertChainValidator {
+    return get(certAnchor, null)
   }
 }

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/validators/X509CertChainValidator.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/validators/X509CertChainValidator.kt
@@ -43,12 +43,8 @@ internal class X509CertChainValidator(certAnchor: Certificate, date: Date? = nul
       return false
     }
 
-    return try {
-      PATH_VALIDATOR.validate(X509FACTORY.generateCertPath(x509Certs), pkixParams)
-      true
-    } catch (e: Exception) {
-      throw e
-    }
+    PATH_VALIDATOR.validate(X509FACTORY.generateCertPath(x509Certs), pkixParams)
+    return true
   }
 
   private fun List<X509Certificate>.maybeDropRoot(): List<X509Certificate> {

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/validators/X509CertChainValidator.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/validators/X509CertChainValidator.kt
@@ -14,8 +14,7 @@ import java.security.cert.CertPathValidator as JCACertPathValidator
  * X.509 specific implementation for validating certificate chains (certificate paths) with
  * a specific set of PKIX parameters.
  */
-internal class X509CertChainValidator(certAnchor: Certificate, date: Date?) : CertChainValidator {
-  constructor(certAnchor: Certificate) : this(certAnchor, null)
+internal class X509CertChainValidator(certAnchor: Certificate, date: Date? = null) : CertChainValidator {
 
   private val pkixParams: PKIXParameters = PKIXParameters(
     setOf(
@@ -47,10 +46,8 @@ internal class X509CertChainValidator(certAnchor: Certificate, date: Date?) : Ce
     return try {
       PATH_VALIDATOR.validate(X509FACTORY.generateCertPath(x509Certs), pkixParams)
       true
-    } catch (e: CertPathValidatorException) {
-      throw e
     } catch (e: Exception) {
-      false
+      throw e
     }
   }
 

--- a/jvm/src/test/kotlin/app/cash/trifle/CertificateTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/CertificateTests.kt
@@ -1,9 +1,18 @@
 package app.cash.trifle
 
+import app.cash.trifle.Certificate.Companion.VerifyResult
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.CSR_MISMATCH
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.EXPIRED
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.INCORRECT_SIGNATURE
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.SUCCESS
+import app.cash.trifle.Certificate.Companion.VerifyResult.Reason.UNSPECIFIED_FAILURE
 import app.cash.trifle.testing.TestCertificateAuthority
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
 import java.security.*
+import java.time.Duration
+import java.time.Instant
+import java.util.Date
 
 internal class CertificateTests {
   @Nested
@@ -11,7 +20,8 @@ internal class CertificateTests {
   inner class CertificateVerifyTests {
     @Test
     fun `test verify() returns true for a properly issued certificate`() {
-      assertTrue(
+      assertEquals(
+        VerifyResult(SUCCESS),
         endEntity.certificate.verify(
           endEntity.certRequest,
           endEntity.certChain.drop(1),
@@ -22,11 +32,11 @@ internal class CertificateTests {
 
     @Test
     fun `test verify() fails for a legitimate certificate from the same CA, but wrong entity`() {
-      val otherEndEntity = certificateAuthority.createTestEndEntity("other_entity")
-      assertFalse(
+      assertEquals(
+        VerifyResult(CSR_MISMATCH),
         endEntity.certificate.verify(
           otherEndEntity.certRequest,
-          otherEndEntity.certChain.drop(1),
+          endEntity.certChain.drop(1),
           certificateAuthority.rootCertificate
         )
       )
@@ -34,18 +44,33 @@ internal class CertificateTests {
 
     @Test
     fun `test verify() fails for a different root certificate`() {
-      assertFalse(
+      assertEquals(
+        VerifyResult(UNSPECIFIED_FAILURE, "Path does not chain with any of the trust anchors"),
+        endEntity.certificate.verify(
+          endEntity.certRequest,
+          otherEndEntity.certChain.drop(1),
+          otherCertificateAuthority.rootCertificate
+        )
+      )
+    }
+
+    @Test
+    fun `test verify() fails for an expired certificate`() {
+      assertEquals(
+        VerifyResult(EXPIRED ,"validity check failed"),
         endEntity.certificate.verify(
           endEntity.certRequest,
           endEntity.certChain.drop(1),
-          TestCertificateAuthority("otherIssuingEntity").rootCertificate
-        )
-      )
+          certificateAuthority.rootCertificate,
+          Date.from(Instant.now().plus(Duration.ofDays(365)))
+      ))
     }
   }
 
   companion object {
     private val certificateAuthority = TestCertificateAuthority("issuingEntity")
+    private val otherCertificateAuthority = TestCertificateAuthority("otherIssuingEntity")
     private val endEntity = certificateAuthority.createTestEndEntity("entity")
+    private val otherEndEntity = otherCertificateAuthority.createTestEndEntity("otherEntity")
   }
 }

--- a/jvm/src/test/kotlin/app/cash/trifle/internal/validators/CertChainValidatorTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/internal/validators/CertChainValidatorTests.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.security.cert.CertPathValidatorException
 
 internal class CertChainValidatorTests {
   @Nested
@@ -18,7 +20,9 @@ internal class CertChainValidatorTests {
 
     @Test
     fun `test validate() returns false for invalid certificate chain`() {
-      assertFalse(validator.validate(TestCertificateAuthority().createTestEndEntity().certChain))
+      assertThrows<CertPathValidatorException> {
+        validator.validate(TestCertificateAuthority().createTestEndEntity().certChain)
+      }
     }
 
     @Test

--- a/jvm/src/test/kotlin/app/cash/trifle/internal/validators/CertChainValidatorTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/internal/validators/CertChainValidatorTests.kt
@@ -19,7 +19,7 @@ internal class CertChainValidatorTests {
     }
 
     @Test
-    fun `test validate() returns false for invalid certificate chain`() {
+    fun `test validate() throws CertPathValidatorException for invalid certificate chain`() {
       assertThrows<CertPathValidatorException> {
         validator.validate(TestCertificateAuthority().createTestEndEntity().certChain)
       }


### PR DESCRIPTION
A simple boolean return value masks the underlying cause of the failure, which clients may wish to know in order to take appropriate corrective action. Expose this, and also expose an API for allowing the caller to specify the validity date, instead of relying purely on the system default.