### PR TITLE
Support more granular cert creation TTLs

### DIFF
--- a/jvm-testing/src/main/kotlin/app/cash/trifle/testing/TestCertificateAuthority.kt
+++ b/jvm-testing/src/main/kotlin/app/cash/trifle/testing/TestCertificateAuthority.kt
@@ -8,7 +8,7 @@ import app.cash.trifle.testing.Fixtures.RAW_ECDSA_P256_KEY_TEMPLATE
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.signature.SignatureConfig
 import java.security.SecureRandom
-import java.time.Period
+import java.time.Duration
 import kotlin.random.Random
 
 /**
@@ -16,7 +16,7 @@ import kotlin.random.Random
  */
 data class TestCertificateAuthority(
   private val certAuthorityName: String = Random.nextInt().toString(),
-  private val validityPeriod: Period = Period.ofDays(1)
+  private val validityPeriod: Duration = Duration.ofDays(1)
 ) {
   private val certificateAuthority: Trifle.CertificateAuthority
   val rootCertificate: Certificate
@@ -34,7 +34,7 @@ data class TestCertificateAuthority(
 
   fun createTestEndEntity(
     entityName: String = Random.nextInt().toString(),
-    validity: Period? = null
+    validity: Duration? = null
   ): TestEndEntity {
     val endEntity = Trifle.EndEntity(GENERATOR.genKeyPair())
     val certRequest = endEntity.createCertRequest(entityName)

--- a/jvm/src/main/kotlin/app/cash/trifle/delegate/CertificateAuthorityDelegate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/delegate/CertificateAuthorityDelegate.kt
@@ -2,7 +2,7 @@ package app.cash.trifle.delegate
 
 import app.cash.trifle.Certificate
 import app.cash.trifle.CertificateRequest
-import java.time.Period
+import java.time.Duration
 
 interface CertificateAuthorityDelegate {
   /**
@@ -14,7 +14,7 @@ interface CertificateAuthorityDelegate {
    */
   fun createRootSigningCertificate(
     entityName: String,
-    validityPeriod: Period,
+    validityPeriod: Duration,
   ): Certificate
 
   /**
@@ -27,11 +27,11 @@ interface CertificateAuthorityDelegate {
   fun signCertificate(
     issuerCertificate: Certificate,
     certificateRequest: CertificateRequest,
-    validity: Period = Period.ofDays(MOBILE_CERTIFICATE_VALIDITY_PERIOD_DAYS),
+    validity: Duration = Duration.ofDays(MOBILE_CERTIFICATE_VALIDITY_PERIOD_DAYS),
   ): Certificate
 
   companion object {
-    // Validity time for device-certificate, currently scoped to 30 day
-    internal const val  MOBILE_CERTIFICATE_VALIDITY_PERIOD_DAYS: Int = 30
+    // Validity time for device-certificate, currently scoped to 30 days
+    internal const val  MOBILE_CERTIFICATE_VALIDITY_PERIOD_DAYS: Long = 30
   }
 }

--- a/jvm/src/main/kotlin/app/cash/trifle/delegate/DelegateImpl.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/delegate/DelegateImpl.kt
@@ -19,8 +19,8 @@ import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils
 import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder
 import java.math.BigInteger
 import java.time.Instant
-import java.time.Period
 import java.util.Date
+import java.time.Duration
 
 /**
  * Shared implementation for certificate enrollment using Trifle Content Signer.
@@ -33,7 +33,7 @@ internal open class DelegateImpl(
   override fun signCertificate(
     issuerCertificate: Certificate,
     certificateRequest: CertificateRequest,
-    validity: Period,
+    validity: Duration,
   ): Certificate = when (certificateRequest) {
     is CertificateRequest.PKCS10Request -> {
       val creationTime = Instant.now()
@@ -61,7 +61,7 @@ internal open class DelegateImpl(
 
   override fun createRootSigningCertificate(
     entityName: String,
-    validityPeriod: Period,
+    validityPeriod: Duration,
   ): Certificate {
     // Trifle Certificates are just wrappers around X.509 certificates. Create one with the
     // given name.

--- a/jvm/src/test/kotlin/app/cash/trifle/TrifleTest.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/TrifleTest.kt
@@ -80,8 +80,8 @@ internal class TrifleTest {
 
     @Test
     fun `test validity period`() {
-      val certTTL = 1
-      val endEntity1 = certificateAuthority.createTestEndEntity("entity", Period.ofDays(certTTL))
+      val certTTL: Long = 1
+      val endEntity1 = certificateAuthority.createTestEndEntity("entity", Duration.ofDays(certTTL))
       val certHolder1 = X509CertificateHolder(endEntity1.certificate.certificate)
 
       val duration =


### PR DESCRIPTION
Currently cert generation uses Period which has the smallest granularity of days. Changing to Duration so it supports seconds if needed for testing.