### PR TITLE
bump up jvm version to 0.2.4 for release

### DIFF
--- a/android/trifle/src/test/java/app/cash/trifle/LibraryVersionUnitTest.kt
+++ b/android/trifle/src/test/java/app/cash/trifle/LibraryVersionUnitTest.kt
@@ -9,7 +9,7 @@ internal class LibraryVersionUnitTest {
     val libraryVersion = LibraryVersion()
     val versionString = libraryVersion.complete()
 
-    assertEquals(versionString, "0.2.3")
+    assertEquals(versionString, "0.2.4")
   }
 
   @Test

--- a/android/trifle/src/test/java/app/cash/trifle/LibraryVersionUnitTest.kt
+++ b/android/trifle/src/test/java/app/cash/trifle/LibraryVersionUnitTest.kt
@@ -9,7 +9,7 @@ internal class LibraryVersionUnitTest {
     val libraryVersion = LibraryVersion()
     val versionString = libraryVersion.complete()
 
-    assertEquals(versionString, "0.2.2")
+    assertEquals(versionString, "0.2.3")
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-VERSION_NAME=0.2.3
+VERSION_NAME=0.2.4
 VERSION_CODE=0
 # Required to publish to Nexus (Default timeout is 1 minute)
 SONATYPE_CONNECT_TIMEOUT_SECONDS=120

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-VERSION_NAME=0.2.2
+VERSION_NAME=0.2.3
 VERSION_CODE=0
 # Required to publish to Nexus (Default timeout is 1 minute)
 SONATYPE_CONNECT_TIMEOUT_SECONDS=120


### PR DESCRIPTION
This version will increase the granularity of creating client certificates TTL.