### PR TITLE
Promote Certificate#verify to a top level api in android sdk

### DIFF
--- a/android/trifle/build.gradle.kts
+++ b/android/trifle/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   androidTestImplementation("androidx.test.ext:junit:1.1.5")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
   androidTestImplementation("junit:junit:4.13.2")
+  androidTestImplementation(project(":jvm-testing"))
 
   api(project(":jvm"))
 }

--- a/android/trifle/src/androidTest/java/app/cash/trifle/TrifleApiTest.kt
+++ b/android/trifle/src/androidTest/java/app/cash/trifle/TrifleApiTest.kt
@@ -1,5 +1,8 @@
 package app.cash.trifle
 
+import app.cash.trifle.TrifleErrors.ExpiredCertificate
+import app.cash.trifle.TrifleErrors.NoTrustAnchor
+import app.cash.trifle.testing.TestCertificateAuthority
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -7,7 +10,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
-
+import java.time.Duration
+import java.time.Instant
+import java.util.Date
 
 class TrifleApiTest {
   @JvmField
@@ -34,5 +39,37 @@ class TrifleApiTest {
 
   @Test fun testDeleteKeyHandle() {
     TrifleApi.delete(keyHandle)
+  }
+
+  @Test
+  fun `testVerify_failsWithNoTrustAnchorForADifferentRootCertificate`() {
+    val result = TrifleApi.verify(
+      endEntity.certificate,
+      endEntity.certRequest,
+      otherEndEntity.certChain.drop(1),
+      otherCertificateAuthority.rootCertificate
+    )
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is NoTrustAnchor)
+  }
+
+  @Test
+  fun testVerify_failsWithExpiredCertificateForAnExpiredCertificate() {
+    val result = TrifleApi.verify(
+      endEntity.certificate,
+      endEntity.certRequest,
+      endEntity.certChain.drop(1),
+      certificateAuthority.rootCertificate,
+      Date.from(Instant.now().plus(Duration.ofDays(365)))
+    )
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is ExpiredCertificate)
+  }
+
+  companion object {
+    private val certificateAuthority = TestCertificateAuthority("issuingEntity")
+    private val otherCertificateAuthority = TestCertificateAuthority("otherIssuingEntity")
+    private val endEntity = certificateAuthority.createTestEndEntity("entity")
+    private val otherEndEntity = otherCertificateAuthority.createTestEndEntity("otherEntity")
   }
 }

--- a/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/Certificate.kt
@@ -1,11 +1,7 @@
 package app.cash.trifle
 
-import app.cash.trifle.CertificateRequest.PKCS10Request
-import app.cash.trifle.TrifleErrors.CSRMismatch
-import app.cash.trifle.internal.validators.CertChainValidatorFactory
 import okio.ByteString.Companion.toByteString
 import org.bouncycastle.cert.X509CertificateHolder
-import java.util.Date
 import app.cash.trifle.protos.api.alpha.Certificate as CertificateProto
 
 /**
@@ -28,48 +24,28 @@ data class Certificate internal constructor(
     ).encode()
 
   /**
-   * Verify that the provided certificate matches what we expected.
-   * It matches the CSR that we have and the root cert is what
-   * we expect.
+   * Verify that the provided certificate matches the CSR that we have.
    *
    * @param certificateRequest -  request used to generate this certificate
-   * @param ancestorCertificateChain - list of certificates preceding *this* one.  Namely, the first
-   *   entry should be the certificate corresponding to the issuer of this certificate, and each
-   *   thereafter should be the issuer of the one before it.
-   * @param anchorCertificate - the trust anchor against which we would like to verify the
-   *   ancestorCertificateChain. This may be the terminal (root) certificate of the chain or may be
-   *   an intermediate certificate in the chain which is already trusted.
-   * @param date - The date to use for verification against certificates' validity windows. If null,
-   *   the current time is used.
    *
    * @return - [Result] indicating [Result.isSuccess] or [Result.isFailure]:
    * - success value is expressed as a [Unit] (Nothing)
-   * - failure value is expressed as a [TrifleErrors]
+   * - failure value is expressed as a [TrifleErrors.CSRMismatch] if attributes are mismatched
    */
-  fun verify(
-    certificateRequest: CertificateRequest,
-    ancestorCertificateChain: List<Certificate>,
-    anchorCertificate: Certificate,
-    date: Date? = null
-  ): Result<Unit> {
-    // First check to see if the certificate chain validates
-    val certChainResult = CertChainValidatorFactory.get(anchorCertificate, date)
-      .validate(listOf(this) + ancestorCertificateChain)
-
-    return certChainResult.mapCatching {
-      val x509Certificate = X509CertificateHolder(certificate)
-      when (certificateRequest) {
-        is PKCS10Request -> {
-          // Certificate chain matches, check with certificate request.
-          // TODO(dcashman): Check other attributes as well.
-          if (certificateRequest.pkcs10Req.subject != x509Certificate.subject ||
-            certificateRequest.pkcs10Req.subjectPublicKeyInfo != x509Certificate.subjectPublicKeyInfo
-          ) {
-            throw CSRMismatch
-          }
+  fun verify(certificateRequest: CertificateRequest): Result<Unit> {
+    val x509Certificate = X509CertificateHolder(certificate)
+    when (certificateRequest) {
+      is CertificateRequest.PKCS10Request -> {
+        // Certificate chain matches, check with certificate request.
+        // TODO(dcashman): Check other attributes as well.
+        if (certificateRequest.pkcs10Req.subject != x509Certificate.subject ||
+          certificateRequest.pkcs10Req.subjectPublicKeyInfo != x509Certificate.subjectPublicKeyInfo
+        ) {
+          return Result.failure(TrifleErrors.CSRMismatch)
         }
       }
     }
+    return Result.success(Unit)
   }
 
   override fun equals(other: Any?): Boolean {

--- a/jvm/src/test/kotlin/app/cash/trifle/CertificateTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/CertificateTests.kt
@@ -5,9 +5,6 @@ import app.cash.trifle.testing.TestCertificateAuthority
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
 import java.security.*
-import java.time.Duration
-import java.time.Instant
-import java.util.Date
 
 internal class CertificateTests {
   @Nested
@@ -15,46 +12,15 @@ internal class CertificateTests {
   inner class CertificateVerifyTests {
     @Test
     fun `test verify() succeeds for a properly issued certificate`() {
-      val result = endEntity.certificate.verify(
-        endEntity.certRequest,
-        endEntity.certChain.drop(1),
-        certificateAuthority.rootCertificate
-      )
+      val result = endEntity.certificate.verify(endEntity.certRequest)
       assertTrue(result.isSuccess)
     }
 
     @Test
     fun `test verify() fails with CSRMismatch for a legitimate certificate from the same CA, but wrong entity`() {
-      val result = endEntity.certificate.verify(
-        otherEndEntity.certRequest,
-        endEntity.certChain.drop(1),
-        certificateAuthority.rootCertificate
-      )
+      val result = endEntity.certificate.verify(otherEndEntity.certRequest)
       assertTrue(result.isFailure)
       assertTrue(result.exceptionOrNull() is CSRMismatch)
-    }
-
-    @Test
-    fun `test verify() fails with NoTrustAnchor for a different root certificate`() {
-      val result = endEntity.certificate.verify(
-        endEntity.certRequest,
-        otherEndEntity.certChain.drop(1),
-        otherCertificateAuthority.rootCertificate
-      )
-      assertTrue(result.isFailure)
-      assertTrue(result.exceptionOrNull() is NoTrustAnchor)
-    }
-
-    @Test
-    fun `test verify() fails with ExpiredCertificate for an expired certificate`() {
-      val result = endEntity.certificate.verify(
-        endEntity.certRequest,
-        endEntity.certChain.drop(1),
-        certificateAuthority.rootCertificate,
-        Date.from(Instant.now().plus(Duration.ofDays(365)))
-      )
-      assertTrue(result.isFailure)
-      assertTrue(result.exceptionOrNull() is ExpiredCertificate)
     }
   }
 


### PR DESCRIPTION
## Description
This PR adds a new top level api to `TrifleApi` to perform verification on a provided `Certificate` object. The arguments remain the same as when it was a helper method exposed as part of the `Certificate` data class.