### PR TITLE
Update tink to 1.9.0

### DIFF
--- a/android/sample_app/build.gradle.kts
+++ b/android/sample_app/build.gradle.kts
@@ -26,6 +26,9 @@ android {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
   }
+  packagingOptions {
+    exclude("META-INF/DEPENDENCIES")
+  }
 }
 
 dependencies {

--- a/jvm-testing/build.gradle.kts
+++ b/jvm-testing/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
     api(project(":jvm"))
+    implementation("com.google.crypto.tink:tink:1.9.0")
 }
 
 configure<com.vanniktech.maven.publish.MavenPublishBaseExtension> {

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -53,7 +53,7 @@ repositories {
 dependencies {
     implementation("org.bouncycastle:bcprov-jdk15to18:1.70")
     implementation("org.bouncycastle:bcpkix-jdk15to18:1.70")
-    api("com.google.crypto.tink:tink:1.7.0")
+    implementation("com.google.crypto.tink:tink:1.9.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
 }
 


### PR DESCRIPTION
## Description
Updates tink dependency to 1.9.0 and update gradle build to use `implementation` instead of `api` to add tink to not leak tink dependency into other modules and only available to at runtime.