### PR TITLE
Extend ByteArrayOutputStream with proper clearing of buffer

### DIFF
--- a/jvm/src/main/kotlin/app/cash/trifle/SignedData.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/SignedData.kt
@@ -43,10 +43,10 @@ data class SignedData internal constructor(
         .get(envelopedData.signingAlgorithm)
 
       // Verify the signature
-      val sigOut = contentVerifier.outputStream
-      sigOut.write(envelopedData.serialize())
+      contentVerifier.outputStream.use {
+        it.write(envelopedData.serialize())
+      }
       val isVerified = contentVerifier.verify(signature)
-      sigOut.close()
 
       if (!isVerified) {
         throw InvalidSignature

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/Buffer.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/Buffer.kt
@@ -1,0 +1,15 @@
+package app.cash.trifle.internal
+
+import org.bouncycastle.util.Arrays
+import java.io.ByteArrayOutputStream
+
+/**
+ * Buffer extends [ByteArrayOutputStream] that zeroes out the underlying buffer whenever
+ *  reset() is called.
+ */
+internal class Buffer : ByteArrayOutputStream() {
+  override fun reset() {
+    Arrays.fill(buf, 0, count, 0.toByte())
+    count = 0;
+  }
+}

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/signers/TinkContentSigner.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/signers/TinkContentSigner.kt
@@ -1,5 +1,6 @@
 package app.cash.trifle.internal.signers
 
+import app.cash.trifle.internal.Buffer
 import app.cash.trifle.internal.TrifleAlgorithmIdentifier
 import app.cash.trifle.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
 import app.cash.trifle.internal.TrifleAlgorithmIdentifier.EdDSAAlgorithmIdentifier
@@ -17,7 +18,6 @@ import com.google.crypto.tink.tinkkey.internal.ProtoKey
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.spec.ECNamedCurveSpec
-import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import java.math.BigInteger
 import java.security.KeyFactory
@@ -32,7 +32,7 @@ import java.security.spec.ECPublicKeySpec
 internal class TinkContentSigner(
   private val privateKeysetHandle: KeysetHandle,
 ) : TrifleContentSigner {
-  private val outputStream: ByteArrayOutputStream = ByteArrayOutputStream()
+  private val outputStream = Buffer()
   private val publicKeySign: PublicKeySign by lazy {
     privateKeysetHandle.getPrimitive(PublicKeySign::class.java)
   }
@@ -76,7 +76,9 @@ internal class TinkContentSigner(
   }
 
   override fun getSignature(): ByteArray {
-    val signedBytes = publicKeySign.sign(outputStream.toByteArray())
+    val signedBytes = outputStream.use {
+      publicKeySign.sign(it.toByteArray())
+    }
     outputStream.reset()
     return signedBytes
   }


### PR DESCRIPTION
## Description
This PR introduces a new `Buffer` class that extends `ByteArrayOutputStream` to override the `reset` method. This properly clears out the underlying buffer used in the `ContentSigner` classes.

The PR also moves any usages of the buffer into an auto-closeable scope. 