### PR TITLE
Dont warn for javax.naming for Android consumers

### DIFF
--- a/android/trifle/consumer-rules.pro
+++ b/android/trifle/consumer-rules.pro
@@ -1,0 +1,2 @@
+## Bouncycastle
+-dontwarn javax.naming.**


### PR DESCRIPTION
## Description
Adds a consumer rule to not warn javax.naming since the class is not available in Android. The class is intrinsically pulled in by BouncyCastle, but not in use for Trifle's intend and purposes. 