### PR TITLE
Downgrade tink to 1.7.0 to temporarily fix Android integration issue

### DIFF
--- a/jvm-testing/build.gradle.kts
+++ b/jvm-testing/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     api(project(":jvm"))
-    implementation("com.google.crypto.tink:tink:1.9.0")
+    implementation("com.google.crypto.tink:tink:1.7.0")
 }
 
 configure<com.vanniktech.maven.publish.MavenPublishBaseExtension> {

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -53,7 +53,7 @@ repositories {
 dependencies {
     implementation("org.bouncycastle:bcprov-jdk15to18:1.70")
     implementation("org.bouncycastle:bcpkix-jdk15to18:1.70")
-    implementation("com.google.crypto.tink:tink:1.9.0")
+    implementation("com.google.crypto.tink:tink:1.7.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
 }
 


### PR DESCRIPTION
## Description
Downgrade tink temporarily back to 1.7.0 to unblock builds that depend on the same transitive dependencies that was introduce in tink 1.9.0.