### PR TITLE
Update jvm/android release for 0.2.8

### DIFF
--- a/android/trifle/src/androidTest/java/app/cash/trifle/LibraryVersionUnitTest.kt
+++ b/android/trifle/src/androidTest/java/app/cash/trifle/LibraryVersionUnitTest.kt
@@ -9,7 +9,7 @@ internal class LibraryVersionUnitTest {
     val libraryVersion = LibraryVersion()
     val versionString = libraryVersion.complete()
 
-    assertEquals(versionString, "0.2.7")
+    assertEquals(versionString, "0.2.8")
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-VERSION_NAME=0.2.7
+VERSION_NAME=0.2.8
 VERSION_CODE=0
 # Required to publish to Nexus (Default timeout is 1 minute)
 SONATYPE_CONNECT_TIMEOUT_SECONDS=120


### PR DESCRIPTION
## Description
This PR creates a release for 0.2.8. There are breaking changes introduced to the Android API. The changes can be found in #167 and the README has been updated to reflect the change. 