### PR TITLE
Re-define TrifleContentVerifierProvider as sealed interface

### DIFF
--- a/jvm/src/main/kotlin/app/cash/trifle/internal/providers/JCAContentVerifierProvider.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/providers/JCAContentVerifierProvider.kt
@@ -4,19 +4,19 @@ import app.cash.trifle.Certificate
 import app.cash.trifle.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
 import app.cash.trifle.internal.TrifleAlgorithmIdentifier.EdDSAAlgorithmIdentifier
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
-import org.bouncycastle.asn1.x509.Certificate as X509Certificate
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.operator.ContentVerifier
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder
+import org.bouncycastle.asn1.x509.Certificate as X509Certificate
 
 /**
  * Internal trifle class to enable delegation to bouncycastle for signing with raw JCE keys.
  */
 internal class JCAContentVerifierProvider(
   private val subjectPublicKeyInfo: SubjectPublicKeyInfo,
-) : TrifleContentVerifierProvider() {
+) : TrifleContentVerifierProvider {
   internal constructor(certificate: Certificate) : this(
     X509Certificate.getInstance(certificate.certificate).subjectPublicKeyInfo
   )

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/providers/TrifleContentVerifierProvider.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/providers/TrifleContentVerifierProvider.kt
@@ -2,4 +2,4 @@ package app.cash.trifle.internal.providers
 
 import org.bouncycastle.operator.ContentVerifierProvider
 
-internal sealed class TrifleContentVerifierProvider : ContentVerifierProvider
+internal sealed interface TrifleContentVerifierProvider : ContentVerifierProvider


### PR DESCRIPTION
## Description
`TrifleContentVerifierProvider` itself does not require storing of states. The PR re-defines the sealed class as a sealed interface instead.