### PR TITLE
Remove internal subpackage(s) from content signers and providers

### DIFF
--- a/jvm/src/main/kotlin/app/cash/trifle/CertificateRequest.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/CertificateRequest.kt
@@ -1,7 +1,7 @@
 package app.cash.trifle
 
-import app.cash.trifle.internal.providers.JCAContentVerifierProvider
 import app.cash.trifle.protos.api.alpha.MobileCertificateRequest
+import app.cash.trifle.providers.jca.JCAContentVerifierProvider
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.bouncycastle.pkcs.PKCS10CertificationRequest

--- a/jvm/src/main/kotlin/app/cash/trifle/SignedData.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/SignedData.kt
@@ -1,8 +1,7 @@
 package app.cash.trifle
 
 import app.cash.trifle.TrifleErrors.InvalidSignature
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier
-import app.cash.trifle.internal.providers.JCAContentVerifierProvider
+import app.cash.trifle.providers.jca.JCAContentVerifierProvider
 import app.cash.trifle.validators.CertChainValidatorFactory
 import okio.ByteString.Companion.toByteString
 import app.cash.trifle.protos.api.alpha.Certificate as CertificateProto

--- a/jvm/src/main/kotlin/app/cash/trifle/TrifleAlgorithmIdentifier.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/TrifleAlgorithmIdentifier.kt
@@ -1,4 +1,4 @@
-package app.cash.trifle.internal
+package app.cash.trifle
 
 import app.cash.trifle.protos.api.alpha.SignedData
 import org.bouncycastle.asn1.ASN1ObjectIdentifier

--- a/jvm/src/main/kotlin/app/cash/trifle/delegate/DelegateImpl.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/delegate/DelegateImpl.kt
@@ -4,7 +4,7 @@ import app.cash.trifle.Certificate
 import app.cash.trifle.CertificateRequest
 import app.cash.trifle.SignedData
 import app.cash.trifle.SignedData.EnvelopedData.Companion.ENVELOPED_DATA_VERSION
-import app.cash.trifle.internal.signers.TrifleContentSigner
+import app.cash.trifle.signers.TrifleContentSigner
 import okio.ByteString.Companion.toByteString
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier

--- a/jvm/src/main/kotlin/app/cash/trifle/delegate/JCADelegate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/delegate/JCADelegate.kt
@@ -1,6 +1,6 @@
 package app.cash.trifle.delegate
 
-import app.cash.trifle.internal.signers.JCAContentSigner
+import app.cash.trifle.signers.jca.JCAContentSigner
 import java.security.KeyPair
 
 /**

--- a/jvm/src/main/kotlin/app/cash/trifle/delegate/TinkDelegate.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/delegate/TinkDelegate.kt
@@ -1,6 +1,6 @@
 package app.cash.trifle.delegate
 
-import app.cash.trifle.internal.signers.TinkContentSigner
+import app.cash.trifle.signers.tink.TinkContentSigner
 import com.google.crypto.tink.KeysetHandle
 
 /**

--- a/jvm/src/main/kotlin/app/cash/trifle/internal/providers/TrifleContentVerifierProvider.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/internal/providers/TrifleContentVerifierProvider.kt
@@ -1,5 +1,0 @@
-package app.cash.trifle.internal.providers
-
-import org.bouncycastle.operator.ContentVerifierProvider
-
-internal sealed interface TrifleContentVerifierProvider : ContentVerifierProvider

--- a/jvm/src/main/kotlin/app/cash/trifle/providers/TrifleContentVerifierProvider.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/providers/TrifleContentVerifierProvider.kt
@@ -1,0 +1,5 @@
+package app.cash.trifle.providers
+
+import org.bouncycastle.operator.ContentVerifierProvider
+
+interface TrifleContentVerifierProvider : ContentVerifierProvider

--- a/jvm/src/main/kotlin/app/cash/trifle/providers/jca/JCAContentVerifierProvider.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/providers/jca/JCAContentVerifierProvider.kt
@@ -1,8 +1,9 @@
-package app.cash.trifle.internal.providers
+package app.cash.trifle.providers.jca
 
 import app.cash.trifle.Certificate
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.EdDSAAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.EdDSAAlgorithmIdentifier
+import app.cash.trifle.providers.TrifleContentVerifierProvider
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.cert.X509CertificateHolder

--- a/jvm/src/main/kotlin/app/cash/trifle/signers/Buffer.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/signers/Buffer.kt
@@ -1,4 +1,4 @@
-package app.cash.trifle.internal
+package app.cash.trifle.signers
 
 import org.bouncycastle.util.Arrays
 import java.io.ByteArrayOutputStream
@@ -7,7 +7,7 @@ import java.io.ByteArrayOutputStream
  * Buffer extends [ByteArrayOutputStream] that zeroes out the underlying buffer whenever
  *  reset() is called.
  */
-internal class Buffer : ByteArrayOutputStream() {
+class Buffer : ByteArrayOutputStream() {
   override fun reset() {
     Arrays.fill(buf, 0, count, 0.toByte())
     count = 0;

--- a/jvm/src/main/kotlin/app/cash/trifle/signers/TrifleContentSigner.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/signers/TrifleContentSigner.kt
@@ -1,10 +1,10 @@
-package app.cash.trifle.internal.signers
+package app.cash.trifle.signers
 
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.operator.ContentSigner
 
-internal interface TrifleContentSigner : ContentSigner {
+interface TrifleContentSigner : ContentSigner {
   fun subjectPublicKeyInfo(): SubjectPublicKeyInfo
 
   override fun getAlgorithmIdentifier(): TrifleAlgorithmIdentifier

--- a/jvm/src/main/kotlin/app/cash/trifle/signers/jca/JCAContentSigner.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/signers/jca/JCAContentSigner.kt
@@ -1,10 +1,11 @@
-package app.cash.trifle.internal.signers
+package app.cash.trifle.signers.jca
 
-import app.cash.trifle.internal.Buffer
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.ECPublicKeyAlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.P256v1AlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.ECPublicKeyAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.P256v1AlgorithmIdentifier
+import app.cash.trifle.signers.Buffer
+import app.cash.trifle.signers.TrifleContentSigner
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.operator.DefaultSignatureNameFinder
 import java.io.OutputStream

--- a/jvm/src/main/kotlin/app/cash/trifle/signers/tink/TinkContentSigner.kt
+++ b/jvm/src/main/kotlin/app/cash/trifle/signers/tink/TinkContentSigner.kt
@@ -1,9 +1,10 @@
-package app.cash.trifle.internal.signers
+package app.cash.trifle.signers.tink
 
-import app.cash.trifle.internal.Buffer
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.EdDSAAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.EdDSAAlgorithmIdentifier
+import app.cash.trifle.signers.Buffer
+import app.cash.trifle.signers.TrifleContentSigner
 import com.google.crypto.tink.KeyTemplate
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.PublicKeySign

--- a/jvm/src/test/kotlin/app/cash/trifle/CertificateRequestTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/CertificateRequestTests.kt
@@ -1,8 +1,7 @@
 package app.cash.trifle
 
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier
-import app.cash.trifle.internal.providers.JCAContentVerifierProvider
-import app.cash.trifle.internal.signers.TrifleContentSigner
+import app.cash.trifle.providers.jca.JCAContentVerifierProvider
+import app.cash.trifle.signers.TrifleContentSigner
 import app.cash.trifle.testing.Fixtures.GENERATOR
 import app.cash.trifle.testing.TestCertificateAuthority
 import okio.ByteString.Companion.toByteString

--- a/jvm/src/test/kotlin/app/cash/trifle/TrifleTest.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/TrifleTest.kt
@@ -2,8 +2,8 @@ package app.cash.trifle
 
 import app.cash.trifle.TrifleErrors.InvalidSignature
 import app.cash.trifle.TrifleErrors.NoTrustAnchor
-import app.cash.trifle.internal.providers.JCAContentVerifierProvider
 import app.cash.trifle.protos.api.alpha.MobileCertificateRequest
+import app.cash.trifle.providers.jca.JCAContentVerifierProvider
 import app.cash.trifle.testing.TestCertificateAuthority
 import okio.ByteString.Companion.encodeUtf8
 import org.bouncycastle.asn1.x500.X500Name

--- a/jvm/src/test/kotlin/app/cash/trifle/providers/TrifleContentVerifierProviderTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/providers/TrifleContentVerifierProviderTests.kt
@@ -1,8 +1,9 @@
-package app.cash.trifle.internal.providers
+package app.cash.trifle.providers
 
 import app.cash.trifle.CertificateRequest
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.Ed25519AlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.Ed25519AlgorithmIdentifier
+import app.cash.trifle.providers.jca.JCAContentVerifierProvider
 import app.cash.trifle.testing.Fixtures.GENERATOR
 import app.cash.trifle.testing.TestCertificateAuthority
 import com.google.crypto.tink.signature.SignatureConfig

--- a/jvm/src/test/kotlin/app/cash/trifle/signers/TrifleContentSignerTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/signers/TrifleContentSignerTests.kt
@@ -1,6 +1,6 @@
-package app.cash.trifle.internal.signers
+package app.cash.trifle.signers
 
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier
 import com.google.crypto.tink.signature.SignatureConfig
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll

--- a/jvm/src/test/kotlin/app/cash/trifle/signers/jca/JCAContentSignerTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/signers/jca/JCAContentSignerTests.kt
@@ -1,6 +1,7 @@
-package app.cash.trifle.internal.signers
+package app.cash.trifle.signers.jca
 
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier
+import app.cash.trifle.signers.TrifleContentSignerTests
 import org.bouncycastle.operator.DefaultSignatureNameFinder
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName

--- a/jvm/src/test/kotlin/app/cash/trifle/signers/tink/TinkContentSignerTests.kt
+++ b/jvm/src/test/kotlin/app/cash/trifle/signers/tink/TinkContentSignerTests.kt
@@ -1,8 +1,9 @@
-package app.cash.trifle.internal.signers
+package app.cash.trifle.signers.tink
 
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
-import app.cash.trifle.internal.TrifleAlgorithmIdentifier.EdDSAAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.ECDSASha256AlgorithmIdentifier
+import app.cash.trifle.TrifleAlgorithmIdentifier.EdDSAAlgorithmIdentifier
+import app.cash.trifle.signers.TrifleContentSignerTests
 import app.cash.trifle.testing.Fixtures.RAW_ECDSA_P256_KEY_TEMPLATE
 import app.cash.trifle.testing.Fixtures.RAW_EDDSA_ED25519_KEY_TEMPLATE
 import com.google.crypto.tink.KeysetHandle


### PR DESCRIPTION
## Description
Rearrange organization of both content signer and provider classes to non-internal sub-packages and into their respective packages based on implementation. 