### PR TITLE
Rename Android API class to Trifle

### DIFF
--- a/android/sample_app/src/main/java/app/cash/trifle/MainActivity.kt
+++ b/android/sample_app/src/main/java/app/cash/trifle/MainActivity.kt
@@ -14,7 +14,7 @@ class MainActivity : AppCompatActivity() {
 
     //Example Trifle use. Shouldn't typically be on the main UI thread, but that's the only reason
     // we're here, so it's ok.
-    val keyHandle = TrifleApi("app.cash.trifle.keys").generateKeyHandle()
+    val keyHandle = Trifle("app.cash.trifle.keys").generateKeyHandle()
 
     setContentView(R.layout.activity_main)
   }

--- a/android/trifle/src/androidTest/java/app/cash/trifle/KeyHandleTest.kt
+++ b/android/trifle/src/androidTest/java/app/cash/trifle/KeyHandleTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 class KeyHandleTest {
   private lateinit var keyHandle: KeyHandle
   @Before fun setUp() {
-    keyHandle = TrifleApi("app.cash.trifle.keys").generateKeyHandle()
+    keyHandle = Trifle("app.cash.trifle.keys").generateKeyHandle()
   }
 
   @Test fun serializeDeserialize() {

--- a/android/trifle/src/androidTest/java/app/cash/trifle/TrifleTest.kt
+++ b/android/trifle/src/androidTest/java/app/cash/trifle/TrifleTest.kt
@@ -17,15 +17,15 @@ import java.time.Instant
 import java.util.Date
 import java.util.UUID
 
-class TrifleApiTest {
+class TrifleTest {
   @JvmField
   @Rule
   val thrown: ExpectedException = ExpectedException.none()
 
-  private val trifleApi = TrifleApi("app.cash.trifle.keys")
+  private val trifle = Trifle("app.cash.trifle.keys")
   private lateinit var keyHandle: KeyHandle
   @Before fun setUp() {
-    keyHandle = trifleApi.generateKeyHandle()
+    keyHandle = trifle.generateKeyHandle()
   }
 
   @Test fun testGenerateKeyHandle() {
@@ -35,21 +35,21 @@ class TrifleApiTest {
   }
 
   @Test fun testIsValid_forCreatedKeyHandle_returnsTrue() {
-    assertTrue(trifleApi.isValid(keyHandle))
+    assertTrue(trifle.isValid(keyHandle))
   }
 
   @Test fun testIsValid_forDeletedKeyHandle_returnsFalse() {
-    trifleApi.delete(keyHandle)
-    assertFalse(trifleApi.isValid(keyHandle))
+    trifle.delete(keyHandle)
+    assertFalse(trifle.isValid(keyHandle))
   }
 
   @Test fun testDeleteKeyHandle() {
-    trifleApi.delete(keyHandle)
+    trifle.delete(keyHandle)
   }
 
   @Test
   fun testVerify_succeeds() {
-    val result = trifleApi.verifyChain(
+    val result = trifle.verifyChain(
       certificateChain = endEntity.certChain
     )
     assertTrue(result.isSuccess)
@@ -57,7 +57,7 @@ class TrifleApiTest {
 
   @Test
   fun testVerifyCertificateValidity_succeeds() {
-    val result = trifleApi.verifyValidity(
+    val result = trifle.verifyValidity(
       endEntity.certificate
     )
     assertTrue(result.isSuccess)
@@ -65,7 +65,7 @@ class TrifleApiTest {
 
   @Test
   fun testVerifyAttributes_succeeds() {
-    val result = trifleApi.verifyCertRequestResponse(
+    val result = trifle.verifyCertRequestResponse(
       endEntity.certificate,
       endEntity.certRequest
     )
@@ -74,7 +74,7 @@ class TrifleApiTest {
 
   @Test
   fun testVerify_failsWithNoTrustAnchorForADifferentRootCertificate() {
-    val result = trifleApi.verifyChain(
+    val result = trifle.verifyChain(
       certificateChain = listOf(endEntity.certificate) + otherEndEntity.certChain.drop(1)
     )
     assertTrue(result.isFailure)
@@ -83,7 +83,7 @@ class TrifleApiTest {
 
   @Test
   fun testVerify_failsWithExpiredCertificateForAnExpiredCertificate() {
-    val result = trifleApi.verifyChain(
+    val result = trifle.verifyChain(
       certificateChain = endEntity.certChain,
       date = Date.from(Instant.now().plus(Duration.ofDays(365)))
     )
@@ -93,7 +93,7 @@ class TrifleApiTest {
 
   @Test
   fun testVerify_failsWithExpiredCertificateForAnExpiredStoredCertificate() {
-    val result = trifleApi.verifyValidity(
+    val result = trifle.verifyValidity(
       endEntity.certificate,
       Date.from(Instant.now().plus(Duration.ofDays(365)))
     )
@@ -103,7 +103,7 @@ class TrifleApiTest {
 
   @Test
   fun testVerify_failsWithNotYetValidCertificateForAStoredCertificateYetToBeValid() {
-    val result = trifleApi.verifyValidity(
+    val result = trifle.verifyValidity(
       endEntity.certificate,
       date = Date.from(Instant.now().minus(Duration.ofDays(1)))
     )
@@ -113,7 +113,7 @@ class TrifleApiTest {
 
   @Test
   fun testVerifyAttributes_failsWithCSRMismatch() {
-    val result = trifleApi.verifyCertRequestResponse(
+    val result = trifle.verifyCertRequestResponse(
       endEntity.certificate,
       otherEndEntity.certRequest
     )

--- a/android/trifle/src/main/java/app/cash/trifle/Trifle.kt
+++ b/android/trifle/src/main/java/app/cash/trifle/Trifle.kt
@@ -5,7 +5,7 @@ import app.cash.trifle.extensions.CertificateChain
 import app.cash.trifle.extensions.CertificateExtensions.validate
 import java.util.Date
 
-class TrifleApi(private val reverseDomain: String) {
+class Trifle(private val reverseDomain: String) {
 
   /**
    * Create a new mobile Trifle keypair for which can be used to create a


### PR DESCRIPTION
## Description
Rename Android API from TrifleApi to Trifle to keep consistency with class names with iOS implementation.