### PR TITLE
Handle NOT_YET_VALID certificates instead of returning unspecified er…

### DIFF
--- a/common/src/main/kotlin/app/cash/trifle/validators/CertChainValidator.kt
+++ b/common/src/main/kotlin/app/cash/trifle/validators/CertChainValidator.kt
@@ -54,18 +54,15 @@ internal sealed interface CertChainValidator {
       } catch (e: CertPathValidatorException) {
         // https://docs.oracle.com/javase/8/docs/api/java/security/cert/PKIXReason.html
         // https://docs.oracle.com/javase/8/docs/api/java/security/cert/CertPathValidatorException.BasicReason.html
-        when (e.reason) {
-          CertPathValidatorException.BasicReason.EXPIRED -> Result.failure(
-            TrifleErrors.ExpiredCertificate
-          )
-          CertPathValidatorException.BasicReason.INVALID_SIGNATURE -> Result.failure(
-            TrifleErrors.InvalidSignature
-          )
-          PKIXReason.NO_TRUST_ANCHOR -> Result.failure(TrifleErrors.NoTrustAnchor)
-          else -> Result.failure(
-            TrifleErrors.UnspecifiedFailure("Unspecified Trifle verification failure", e)
-          )
-        }
+        Result.failure(
+          when (e.reason) {
+            CertPathValidatorException.BasicReason.EXPIRED -> TrifleErrors.ExpiredCertificate
+            CertPathValidatorException.BasicReason.NOT_YET_VALID -> TrifleErrors.NotValidYetCertificate
+            CertPathValidatorException.BasicReason.INVALID_SIGNATURE -> TrifleErrors.InvalidSignature
+            PKIXReason.NO_TRUST_ANCHOR -> TrifleErrors.NoTrustAnchor
+            else -> TrifleErrors.UnspecifiedFailure("Unspecified Trifle verification failure", e)
+          }
+        )
       } catch (e: Exception) {
         Result.failure(
           TrifleErrors.UnspecifiedFailure(

--- a/common/src/test/kotlin/app/cash/trifle/validators/CertChainValidatorTests.kt
+++ b/common/src/test/kotlin/app/cash/trifle/validators/CertChainValidatorTests.kt
@@ -1,5 +1,7 @@
 package app.cash.trifle.validators
 
+import app.cash.trifle.TrifleErrors.NotValidYetCertificate
+import app.cash.trifle.TrifleErrors.ExpiredCertificate
 import app.cash.trifle.TrifleErrors.InvalidCertPath
 import app.cash.trifle.TrifleErrors.NoTrustAnchor
 import app.cash.trifle.testing.TestCertificateAuthority
@@ -8,6 +10,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.Date
 
 internal class CertChainValidatorTests {
   @Nested
@@ -38,11 +43,33 @@ internal class CertChainValidatorTests {
       assertTrue(result.isFailure)
       assertTrue(result.exceptionOrNull() is InvalidCertPath)
     }
+
+    @Test
+    fun `test validate() fails with NotValidYetCertificate`() {
+      val validator = X509CertChainValidator(
+        certificateAuthority.rootCertificate,
+        Date.from(Instant.now().minus(Duration.ofDays(1)))
+      )
+      val result = validator.validate(endEntity.certChain)
+      assertTrue(result.exceptionOrNull() is NotValidYetCertificate)
+    }
+
+    @Test
+    fun `test validate() fails with ExpiredCertificate`() {
+      val validator = X509CertChainValidator(
+        certificateAuthority.rootCertificate,
+        Date.from(Instant.now().plus(Duration.ofDays(2)))
+      )
+      val result = validator.validate(endEntity.certChain)
+      assertTrue(result.exceptionOrNull() is ExpiredCertificate)
+    }
   }
 
   companion object {
     private val certificateAuthority = TestCertificateAuthority()
-    private val endEntity = certificateAuthority.createTestEndEntity()
+    private val endEntity = certificateAuthority.createTestEndEntity(
+      validity = Duration.ofDays(1)
+    )
     private val validator = X509CertChainValidator(certificateAuthority.rootCertificate)
   }
 }


### PR DESCRIPTION
…ror.

This PR expands error handling in the CertChainValidator to include the NOT_YET_VALID case, and adds tests to make sure we are handling these and ExpiredCertificate errors correctly.

Note that Android behavior is different from iOS currently: the later returns platform errors directly. Long-term, we may want to move the Android implementation in the same direction.