### PR TITLE
Redact SignedData and EnvelopedData toString by default and expose helper methods for unredacted values

### DIFF
--- a/common/src/main/kotlin/app/cash/trifle/SignedData.kt
+++ b/common/src/main/kotlin/app/cash/trifle/SignedData.kt
@@ -79,6 +79,11 @@ data class SignedData internal constructor(
     }
   ).encode()
 
+  fun toPlaintextString(): String =
+    "SignedData(enveloped_data=${envelopedData.toPlaintextString()}, " +
+    "signature=$signature, " +
+    "certificates=$certificates)"
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false
@@ -131,6 +136,9 @@ data class SignedData internal constructor(
       data_ = data.toByteString()
     ).encode()
 
+    fun toPlaintextString(): String =
+      "EnvelopedData(version=$version, signingAlgorithm=$signingAlgorithm, data=$data)"
+
     override fun equals(other: Any?): Boolean {
       if (this === other) return true
       if (javaClass != other?.javaClass) return false
@@ -150,6 +158,9 @@ data class SignedData internal constructor(
       result = 31 * result + data.contentHashCode()
       return result
     }
+
+    override fun toString(): String =
+      "EnvelopedData(version=$version, signingAlgorithm=$signingAlgorithm, data=[REDACTED])"
 
     internal companion object {
       internal const val ENVELOPED_DATA_VERSION: Int = 0

--- a/common/src/test/kotlin/app/cash/trifle/TrifleTest.kt
+++ b/common/src/test/kotlin/app/cash/trifle/TrifleTest.kt
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.Duration
+import kotlin.test.assertContains
+import kotlin.test.assertContentEquals
 
 internal class TrifleTest {
   @Nested
@@ -173,6 +175,28 @@ internal class TrifleTest {
     @Test
     fun `test createSignedData succeeds`() {
       assertEquals(endEntity.createSignedData(rawData).envelopedData.data, rawData)
+    }
+
+    @Test
+    fun `test createSignedData succeeds with SignedData#toString properly redacted`() {
+      val signedData = endEntity.createSignedData(rawData)
+
+      assertTrue(signedData.toString().contains("[REDACTED]"))
+      assertTrue(signedData.envelopedData.toString().contains("[REDACTED]"))
+
+      assertFalse(signedData.toString().contains(rawData.toString()))
+      assertFalse(signedData.envelopedData.toString().contains(rawData.toString()))
+    }
+
+    @Test
+    fun `test createSignedData succeeds with SignedData#toPlaintextString not redacted`() {
+      val signedData = endEntity.createSignedData(rawData)
+
+      assertTrue(signedData.toPlaintextString().contains(rawData.toString()))
+      assertTrue(signedData.envelopedData.toPlaintextString().contains(rawData.toString()))
+
+      assertFalse(signedData.toPlaintextString().contains("[REDACTED]"))
+      assertFalse(signedData.envelopedData.toPlaintextString().contains("[REDACTED]"))
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR defaults toString methods to redact the data field as it might contain sensitive information. This PR also exposes a secondary method in the scenario that developers would want to print data in plaintext.