### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.github/workflows/swift_build.yml
+++ b/.github/workflows/swift_build.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Install Pod Dependencies
         run: cd ios/Example && pod install
         shell: bash
-      
-      - name: Run tests
+
+      - name: Run CocoaPod tests
         run:  xcodebuild test -workspace ios/Example/Trifle.xcworkspace -scheme Trifle-Example  -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -configuration Debug
+
+      - name: Run Swift Package Manager tests
+        run: |
+          swift build --sdk "$(xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk" --triple "arm64-apple-ios14.0-simulator"

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ build
 .externalNativeBuild
 .cxx
 local.properties
+
+# SPM
+.build

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "eae3917e9693897f6a03267f06d2b1d3ffb475a64065c99d0920e0637b7085c5",
+  "pins" : [
+    {
+      "identity" : "wire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/square/wire",
+      "state" : {
+        "revision" : "ae34c3a2cfdea31ea7cb8328c84c2a8bc1d0f25f",
+        "version" : "4.7.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.10
+
+import PackageDescription
+
+let package = Package(
+	name: "Trifle",
+	platforms: [
+		.iOS(.v14),
+        .macOS(.v10_15),
+	],
+	products: [
+		.library(
+			name: "Trifle",
+			targets: ["Trifle"]
+		),
+	],
+	dependencies: [
+		.package(
+            url: "https://github.com/square/wire",
+            .upToNextMinor(from: "4.7.0")
+        ),
+	],
+	targets: [
+		.target(
+			name: "Trifle",
+			dependencies: [
+                .product(name: "Wire", package: "wire"),
+            ],
+			path: "ios/Trifle/Sources"
+		),
+	]
+)

--- a/Trifle.podspec
+++ b/Trifle.podspec
@@ -16,7 +16,7 @@ Security functionality for interoperability/interaction with core services.
 
   s.source_files = 'ios/Trifle/Sources/**/*.swift'
 
-  s.dependency 'Wire', '~> 4'
+  s.dependency 'Wire', '~> 4.7'
 
-  s.swift_versions = '5.0.1'
+  s.swift_versions = '5.8'
 end

--- a/ios/Example/Podfile.lock
+++ b/ios/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Trifle (0.2.4):
-    - Wire (~> 4)
-  - Wire (4.5.1)
+  - Trifle (0.2.5):
+    - Wire (~> 4.7)
+  - Wire (4.7.2)
   - WireCompiler (4.5.1)
 
 DEPENDENCIES:
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Trifle: bb8422a8904ddfa192d5b7beedfbf5505087c947
-  Wire: b07a2ff1c4cd4b71f5ae26771cdd13fc7868c9df
+  Trifle: 640389000f04f073a54b82d237b2ac5afb081a80
+  Wire: 193a6a025213e0c2d13875fdef225df34d10b775
   WireCompiler: 417c2ac583c01de328010738658758556ea92a92
 
 PODFILE CHECKSUM: 4b8d6c2fc4c9668821977302cb1ff5c5891d9920
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.15.0


### PR DESCRIPTION
Add's SPM support to Trifle. Primarily adds a `Package.swift` file and a relevant github action test to ensure it builds.

NOTE: i updated the spec and the Package.swift to specify Wire ~4.7 explicitly because Trifle does not seem to build with Write 4.8+