### PR TITLE
Update to Wire 4.9.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "eae3917e9693897f6a03267f06d2b1d3ffb475a64065c99d0920e0637b7085c5",
+  "originHash" : "08d31d385d95b89bc6a315ac2f64f83b26bb0dc63aa9e3cc6992dba35833c7fb",
   "pins" : [
     {
       "identity" : "wire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/square/wire",
       "state" : {
-        "revision" : "ae34c3a2cfdea31ea7cb8328c84c2a8bc1d0f25f",
-        "version" : "4.7.2"
+        "revision" : "f0972bb728ffe2d92b376e501e4297a3c33111e2",
+        "version" : "4.9.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
 	name: "Trifle",
 	platforms: [
 		.iOS(.v14),
-        .macOS(.v10_15),
+		.macOS(.v10_15),
 	],
 	products: [
 		.library(
@@ -16,16 +16,16 @@ let package = Package(
 	],
 	dependencies: [
 		.package(
-            url: "https://github.com/square/wire",
-            .upToNextMinor(from: "4.7.0")
-        ),
+			url: "https://github.com/square/wire",
+			exact: "4.9.3"
+		),
 	],
 	targets: [
 		.target(
 			name: "Trifle",
 			dependencies: [
-                .product(name: "Wire", package: "wire"),
-            ],
+				.product(name: "Wire", package: "wire"),
+			],
 			path: "ios/Trifle/Sources"
 		),
 	]

--- a/Trifle.podspec
+++ b/Trifle.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Trifle'
-  s.version          = '0.2.6'
+  s.version          = '0.2.7'
   s.summary          = 'Security related functions.'
 
   s.description      = <<-DESC

--- a/Trifle.podspec
+++ b/Trifle.podspec
@@ -16,7 +16,7 @@ Security functionality for interoperability/interaction with core services.
 
   s.source_files = 'ios/Trifle/Sources/**/*.swift'
 
-  s.dependency 'Wire', '~> 4.7'
+  s.dependency 'Wire', '4.9.3'
 
   s.swift_versions = '5.8'
 end

--- a/ios/Example/Podfile
+++ b/ios/Example/Podfile
@@ -14,5 +14,5 @@ end
 target 'Trifle_macOS_Dummy' do
   platform :macos, '10.15'
   
-  pod 'WireCompiler', '4.5.1'
+  pod 'WireCompiler', '4.9.3'
 end

--- a/ios/Example/Podfile.lock
+++ b/ios/Example/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Trifle (0.2.5):
-    - Wire (~> 4.7)
-  - Wire (4.7.2)
-  - WireCompiler (4.5.1)
+  - Trifle (0.2.6):
+    - Wire (= 4.9.3)
+  - Wire (4.9.3)
+  - WireCompiler (4.9.3)
 
 DEPENDENCIES:
   - Trifle (from `../../`)
-  - WireCompiler (= 4.5.1)
+  - WireCompiler (= 4.9.3)
 
 SPEC REPOS:
   trunk:
@@ -18,10 +18,10 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Trifle: 640389000f04f073a54b82d237b2ac5afb081a80
-  Wire: 193a6a025213e0c2d13875fdef225df34d10b775
-  WireCompiler: 417c2ac583c01de328010738658758556ea92a92
+  Trifle: 312c21467e3d5e77099d92467aa582c7cfd92edf
+  Wire: 292dc634a9f4517dd9761004ebb11e8725aa5436
+  WireCompiler: dedff6f7d972d766a6adbe5a0c8753127a4fbadd
 
-PODFILE CHECKSUM: 4b8d6c2fc4c9668821977302cb1ff5c5891d9920
+PODFILE CHECKSUM: 7d1505a0ab359616e344524c637456fbb16ed735
 
 COCOAPODS: 1.15.0

--- a/ios/Example/Tests/CertificateTests.swift
+++ b/ios/Example/Tests/CertificateTests.swift
@@ -44,8 +44,14 @@ final class CertificateTests: XCTestCase {
     
     func testExpiredCertificate() throws {
                 
-        let validCertificate = Certificate(version: 0, certificate: TestFixtures.validCertEncoded)
-        let expiredCertificate = Certificate(version: 0, certificate: TestFixtures.expiredCertEncoded)
+        let validCertificate = Certificate(configure: { cert in
+            cert.version = 0
+            cert.certificate = TestFixtures.validCertEncoded
+        })
+        let expiredCertificate = Certificate(configure: { cert in
+            cert.version = 0
+            cert.certificate = TestFixtures.expiredCertEncoded
+        })
 
         XCTAssertTrue(try validCertificate.verify(intermediateChain: Array<Certificate>()))
     

--- a/ios/Trifle/Sources/Generated/Protos/Certificate.swift
+++ b/ios/Trifle/Sources/Generated/Protos/Certificate.swift
@@ -16,20 +16,34 @@ public struct Certificate {
      * the Trifle library how to interpret the certificate bytes.
      * Required.
      */
+    @ProtoDefaulted
     public var version: UInt32?
     /**
      * The current representation is fundamentally an x.509 certificate as defined in
      * https://datatracker.ietf.org/doc/html/rfc5280, with most of the fields and features ignored.
      */
-    public var certificate: Data?
-    public var unknownFields: Data = .init()
+    @ProtoDefaulted
+    public var certificate: Foundation.Data?
+    public var unknownFields: Foundation.Data = .init()
 
-    public init(version: UInt32? = nil, certificate: Data? = nil) {
-        self.version = version
-        self.certificate = certificate
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
+        configure(&self)
     }
 
 }
+
+#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
+extension Certificate {
+
+    @_disfavoredOverload
+    @available(*, deprecated)
+    public init(version: Swift.UInt32? = nil, certificate: Foundation.Data? = nil) {
+        self._version.wrappedValue = version
+        self._certificate.wrappedValue = certificate
+    }
+
+}
+#endif
 
 #if !WIRE_REMOVE_EQUATABLE
 extension Certificate : Equatable {
@@ -46,51 +60,64 @@ extension Certificate : Sendable {
 }
 #endif
 
-extension Certificate : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
-        return "type.googleapis.com/app.cash.trifle.api.alpha.Certificate"
+extension Certificate : ProtoDefaultedValue {
+
+    public static var defaultedValue: Certificate {
+        Certificate()
     }
 }
 
-extension Certificate : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var version: UInt32? = nil
-        var certificate: Data? = nil
+extension Certificate : ProtoMessage {
 
-        let token = try reader.beginMessage()
-        while let tag = try reader.nextTag(token: token) {
+    public static func protoMessageTypeURL() -> Swift.String {
+        return "type.googleapis.com/app.cash.trifle.api.alpha.Certificate"
+    }
+
+}
+
+extension Certificate : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var version: Swift.UInt32? = nil
+        var certificate: Foundation.Data? = nil
+
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
             switch tag {
-            case 1: version = try reader.decode(UInt32.self)
-            case 2: certificate = try reader.decode(Data.self)
-            default: try reader.readUnknownField(tag: tag)
+            case 1: version = try protoReader.decode(Swift.UInt32.self)
+            case 2: certificate = try protoReader.decode(Foundation.Data.self)
+            default: try protoReader.readUnknownField(tag: tag)
             }
         }
-        self.unknownFields = try reader.endMessage(token: token)
+        self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.version = version
-        self.certificate = certificate
+        self._version.wrappedValue = version
+        self._certificate.wrappedValue = certificate
     }
 
-    public func encode(to writer: ProtoWriter) throws {
-        try writer.encode(tag: 1, value: self.version)
-        try writer.encode(tag: 2, value: self.certificate)
-        try writer.writeUnknownFields(unknownFields)
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try protoWriter.encode(tag: 1, value: self.version)
+        try protoWriter.encode(tag: 2, value: self.certificate)
+        try protoWriter.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Certificate : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.version = try container.decodeIfPresent(UInt32.self, forKey: "version")
-        self.certificate = try container.decodeIfPresent(stringEncoded: Data.self, forKey: "certificate")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self._version.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, forKey: "version")
+        self._certificate.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, forKey: "certificate")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.version, forKey: "version")
         try container.encodeIfPresent(stringEncoded: self.certificate, forKey: "certificate")
     }
+
 }
 #endif

--- a/ios/Trifle/Sources/Generated/Protos/MobileCertificateRequest.swift
+++ b/ios/Trifle/Sources/Generated/Protos/MobileCertificateRequest.swift
@@ -16,20 +16,34 @@ public struct MobileCertificateRequest {
      * Version describing the current format of the MobileCertificateRequest.
      * Required.
      */
+    @ProtoDefaulted
     public var version: UInt32?
     /**
      * Bytes representing a Certificate Request as specified in the PKCS10 RFC, see
      * https://datatracker.ietf.org/doc/html/rfc5967 for details.
      */
-    public var pkcs10_request: Data?
-    public var unknownFields: Data = .init()
+    @ProtoDefaulted
+    public var pkcs10_request: Foundation.Data?
+    public var unknownFields: Foundation.Data = .init()
 
-    public init(version: UInt32? = nil, pkcs10_request: Data? = nil) {
-        self.version = version
-        self.pkcs10_request = pkcs10_request
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
+        configure(&self)
     }
 
 }
+
+#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
+extension MobileCertificateRequest {
+
+    @_disfavoredOverload
+    @available(*, deprecated)
+    public init(version: Swift.UInt32? = nil, pkcs10_request: Foundation.Data? = nil) {
+        self._version.wrappedValue = version
+        self._pkcs10_request.wrappedValue = pkcs10_request
+    }
+
+}
+#endif
 
 #if !WIRE_REMOVE_EQUATABLE
 extension MobileCertificateRequest : Equatable {
@@ -46,52 +60,65 @@ extension MobileCertificateRequest : Sendable {
 }
 #endif
 
-extension MobileCertificateRequest : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
-        return "type.googleapis.com/app.cash.trifle.api.alpha.MobileCertificateRequest"
+extension MobileCertificateRequest : ProtoDefaultedValue {
+
+    public static var defaultedValue: MobileCertificateRequest {
+        MobileCertificateRequest()
     }
 }
 
-extension MobileCertificateRequest : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var version: UInt32? = nil
-        var pkcs10_request: Data? = nil
+extension MobileCertificateRequest : ProtoMessage {
 
-        let token = try reader.beginMessage()
-        while let tag = try reader.nextTag(token: token) {
+    public static func protoMessageTypeURL() -> Swift.String {
+        return "type.googleapis.com/app.cash.trifle.api.alpha.MobileCertificateRequest"
+    }
+
+}
+
+extension MobileCertificateRequest : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var version: Swift.UInt32? = nil
+        var pkcs10_request: Foundation.Data? = nil
+
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
             switch tag {
-            case 1: version = try reader.decode(UInt32.self)
-            case 2: pkcs10_request = try reader.decode(Data.self)
-            default: try reader.readUnknownField(tag: tag)
+            case 1: version = try protoReader.decode(Swift.UInt32.self)
+            case 2: pkcs10_request = try protoReader.decode(Foundation.Data.self)
+            default: try protoReader.readUnknownField(tag: tag)
             }
         }
-        self.unknownFields = try reader.endMessage(token: token)
+        self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.version = version
-        self.pkcs10_request = pkcs10_request
+        self._version.wrappedValue = version
+        self._pkcs10_request.wrappedValue = pkcs10_request
     }
 
-    public func encode(to writer: ProtoWriter) throws {
-        try writer.encode(tag: 1, value: self.version)
-        try writer.encode(tag: 2, value: self.pkcs10_request)
-        try writer.writeUnknownFields(unknownFields)
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try protoWriter.encode(tag: 1, value: self.version)
+        try protoWriter.encode(tag: 2, value: self.pkcs10_request)
+        try protoWriter.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension MobileCertificateRequest : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.version = try container.decodeIfPresent(UInt32.self, forKey: "version")
-        self.pkcs10_request = try container.decodeIfPresent(stringEncoded: Data.self, firstOfKeys: "pkcs10Request", "pkcs10_request")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self._version.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, forKey: "version")
+        self._pkcs10_request.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "pkcs10Request", "pkcs10_request")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
 
         try container.encodeIfPresent(self.version, forKey: "version")
         try container.encodeIfPresent(stringEncoded: self.pkcs10_request, forKey: preferCamelCase ? "pkcs10Request" : "pkcs10_request")
     }
+
 }
 #endif

--- a/ios/Trifle/Sources/Generated/Protos/MobileCertificateResponse.swift
+++ b/ios/Trifle/Sources/Generated/Protos/MobileCertificateResponse.swift
@@ -5,14 +5,26 @@ import Wire
 
 public struct MobileCertificateResponse {
 
-    public var certificates: [Data]
-    public var unknownFields: Data = .init()
+    public var certificates: [Foundation.Data] = []
+    public var unknownFields: Foundation.Data = .init()
 
-    public init(certificates: [Data] = []) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
+        configure(&self)
+    }
+
+}
+
+#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
+extension MobileCertificateResponse {
+
+    @_disfavoredOverload
+    @available(*, deprecated)
+    public init(certificates: [Foundation.Data] = []) {
         self.certificates = certificates
     }
 
 }
+#endif
 
 #if !WIRE_REMOVE_EQUATABLE
 extension MobileCertificateResponse : Equatable {
@@ -29,48 +41,61 @@ extension MobileCertificateResponse : Sendable {
 }
 #endif
 
-extension MobileCertificateResponse : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
-        return "type.googleapis.com/app.cash.trifle.api.alpha.MobileCertificateResponse"
+extension MobileCertificateResponse : ProtoDefaultedValue {
+
+    public static var defaultedValue: MobileCertificateResponse {
+        MobileCertificateResponse()
     }
 }
 
-extension MobileCertificateResponse : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var certificates: [Data] = []
+extension MobileCertificateResponse : ProtoMessage {
 
-        let token = try reader.beginMessage()
-        while let tag = try reader.nextTag(token: token) {
+    public static func protoMessageTypeURL() -> Swift.String {
+        return "type.googleapis.com/app.cash.trifle.api.alpha.MobileCertificateResponse"
+    }
+
+}
+
+extension MobileCertificateResponse : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var certificates: [Foundation.Data] = []
+
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
             switch tag {
-            case 1: try reader.decode(into: &certificates)
-            default: try reader.readUnknownField(tag: tag)
+            case 1: try protoReader.decode(into: &certificates)
+            default: try protoReader.readUnknownField(tag: tag)
             }
         }
-        self.unknownFields = try reader.endMessage(token: token)
+        self.unknownFields = try protoReader.endMessage(token: token)
 
         self.certificates = certificates
     }
 
-    public func encode(to writer: ProtoWriter) throws {
-        try writer.encode(tag: 1, value: self.certificates)
-        try writer.writeUnknownFields(unknownFields)
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try protoWriter.encode(tag: 1, value: self.certificates)
+        try protoWriter.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension MobileCertificateResponse : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.certificates = try container.decodeProtoArray(Data.self, forKey: "certificates")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.certificates = try container.decodeProtoArray(Foundation.Data.self, forKey: "certificates")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
         if includeDefaults || !self.certificates.isEmpty {
             try container.encodeProtoArray(self.certificates, forKey: "certificates")
         }
     }
+
 }
 #endif

--- a/ios/Trifle/Sources/Generated/Protos/SignedData.swift
+++ b/ios/Trifle/Sources/Generated/Protos/SignedData.swift
@@ -15,12 +15,14 @@ public struct SignedData {
      * The data which has been signed. This should deserialize to a EnvelopedData
      * message after verification.
      */
-    public var enveloped_data: Data?
+    @ProtoDefaulted
+    public var enveloped_data: Foundation.Data?
     /**
-     * The actual signature over the signed object, generated according to
+     * The actual signature over the signed enveloped data, generated according to
      * the algorithm and private key with the associated certificate.
      */
-    public var signature: Data?
+    @ProtoDefaulted
+    public var signature: Foundation.Data?
     /**
      * The Trifle certificates that include the leaf, intermediate (if any), and root,
      * in the order described.
@@ -31,29 +33,135 @@ public struct SignedData {
      * The leaf certificate embeds the verification (public) key. The certificate must
      * match the certificate of the signed data.
      */
-    public var certificates: [Certificate]
-    public var unknownFields: Data = .init()
+    public var certificates: [Certificate] = []
+    public var unknownFields: Foundation.Data = .init()
 
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
+        configure(&self)
+    }
+
+}
+
+#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
+extension SignedData {
+
+    @_disfavoredOverload
+    @available(*, deprecated)
     public init(
-        enveloped_data: Data? = nil,
-        signature: Data? = nil,
+        enveloped_data: Foundation.Data? = nil,
+        signature: Foundation.Data? = nil,
         certificates: [Certificate] = []
     ) {
-        self.enveloped_data = enveloped_data
-        self.signature = signature
+        self._enveloped_data.wrappedValue = enveloped_data
+        self._signature.wrappedValue = signature
         self.certificates = certificates
     }
+
+}
+#endif
+
+#if !WIRE_REMOVE_EQUATABLE
+extension SignedData : Equatable {
+}
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension SignedData : Hashable {
+}
+#endif
+
+#if swift(>=5.5)
+extension SignedData : Sendable {
+}
+#endif
+
+extension SignedData : ProtoDefaultedValue {
+
+    public static var defaultedValue: SignedData {
+        SignedData()
+    }
+}
+
+extension SignedData : ProtoMessage {
+
+    public static func protoMessageTypeURL() -> Swift.String {
+        return "type.googleapis.com/app.cash.trifle.api.alpha.SignedData"
+    }
+
+}
+
+extension SignedData : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var enveloped_data: Foundation.Data? = nil
+        var signature: Foundation.Data? = nil
+        var certificates: [Certificate] = []
+
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
+            switch tag {
+            case 1: enveloped_data = try protoReader.decode(Foundation.Data.self)
+            case 2: signature = try protoReader.decode(Foundation.Data.self)
+            case 3: try protoReader.decode(into: &certificates)
+            default: try protoReader.readUnknownField(tag: tag)
+            }
+        }
+        self.unknownFields = try protoReader.endMessage(token: token)
+
+        self._enveloped_data.wrappedValue = enveloped_data
+        self._signature.wrappedValue = signature
+        self.certificates = certificates
+    }
+
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try protoWriter.encode(tag: 1, value: self.enveloped_data)
+        try protoWriter.encode(tag: 2, value: self.signature)
+        try protoWriter.encode(tag: 3, value: self.certificates)
+        try protoWriter.writeUnknownFields(unknownFields)
+    }
+
+}
+
+#if !WIRE_REMOVE_CODABLE
+extension SignedData : Codable {
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self._enveloped_data.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "envelopedData", "enveloped_data")
+        self._signature.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, forKey: "signature")
+        self.certificates = try container.decodeProtoArray(Certificate.self, forKey: "certificates")
+    }
+
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
+        let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
+
+        try container.encodeIfPresent(stringEncoded: self.enveloped_data, forKey: preferCamelCase ? "envelopedData" : "enveloped_data")
+        try container.encodeIfPresent(stringEncoded: self.signature, forKey: "signature")
+        if includeDefaults || !self.certificates.isEmpty {
+            try container.encodeProtoArray(self.certificates, forKey: "certificates")
+        }
+    }
+
+}
+#endif
+
+/**
+ * Subtypes within SignedData
+ */
+extension SignedData {
 
     /**
      * Signing algorithms supported by Trifle
      */
-    public enum Algorithm : UInt32, CaseIterable, ProtoEnum {
+    public enum Algorithm : Swift.Int32, Swift.CaseIterable, Wire.ProtoEnum {
 
         case DO_NOT_USE = 0
         case ECDSA_SHA256 = 1
         case ED25519 = 2
 
-        public var description: String {
+        public var description: Swift.String {
             switch self {
             case .DO_NOT_USE: return "DO_NOT_USE"
             case .ECDSA_SHA256: return "ECDSA_SHA256"
@@ -75,25 +183,21 @@ public struct SignedData {
          * Verifier should verify that this matches the signed version to prevent
          * rollback attacks.
          */
-        public var version: UInt32?
+        @Wire.ProtoDefaulted
+        public var version: Swift.UInt32?
         /**
          * Signing algorithm used to sign over the SigningMessage message.
          */
-        public var signing_algorithm: Algorithm?
+        public var signing_algorithm: SignedData.Algorithm?
         /**
          * Data provided directly by the Trifle library client.
          */
-        public var data: Data?
-        public var unknownFields: Data = .init()
+        @Wire.ProtoDefaulted
+        public var data: Foundation.Data?
+        public var unknownFields: Foundation.Data = .init()
 
-        public init(
-            version: UInt32? = nil,
-            signing_algorithm: Algorithm? = nil,
-            data: Data? = nil
-        ) {
-            self.version = version
-            self.signing_algorithm = signing_algorithm
-            self.data = data
+        public init(configure: (inout Self) -> Swift.Void = { _ in }) {
+            configure(&self)
         }
 
     }
@@ -102,6 +206,24 @@ public struct SignedData {
 
 #if swift(>=5.5)
 extension SignedData.Algorithm : Sendable {
+}
+#endif
+
+#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
+extension SignedData.EnvelopedData {
+
+    @_disfavoredOverload
+    @available(*, deprecated)
+    public init(
+        version: Swift.UInt32? = nil,
+        signing_algorithm: SignedData.Algorithm? = nil,
+        data: Foundation.Data? = nil
+    ) {
+        self._version.wrappedValue = version
+        self.signing_algorithm = signing_algorithm
+        self._data.wrappedValue = data
+    }
+
 }
 #endif
 
@@ -120,132 +242,71 @@ extension SignedData.EnvelopedData : Sendable {
 }
 #endif
 
-extension SignedData.EnvelopedData : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
-        return "type.googleapis.com/app.cash.trifle.api.alpha.SignedData.EnvelopedData"
+extension SignedData.EnvelopedData : ProtoDefaultedValue {
+
+    public static var defaultedValue: SignedData.EnvelopedData {
+        SignedData.EnvelopedData()
     }
 }
 
-extension SignedData.EnvelopedData : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var version: UInt32? = nil
-        var signing_algorithm: SignedData.Algorithm? = nil
-        var data: Data? = nil
+extension SignedData.EnvelopedData : ProtoMessage {
 
-        let token = try reader.beginMessage()
-        while let tag = try reader.nextTag(token: token) {
+    public static func protoMessageTypeURL() -> Swift.String {
+        return "type.googleapis.com/app.cash.trifle.api.alpha.SignedData.EnvelopedData"
+    }
+
+}
+
+extension SignedData.EnvelopedData : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var version: Swift.UInt32? = nil
+        var signing_algorithm: SignedData.Algorithm? = nil
+        var data: Foundation.Data? = nil
+
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
             switch tag {
-            case 1: version = try reader.decode(UInt32.self)
-            case 2: signing_algorithm = try reader.decode(SignedData.Algorithm.self)
-            case 3: data = try reader.decode(Data.self)
-            default: try reader.readUnknownField(tag: tag)
+            case 1: version = try protoReader.decode(Swift.UInt32.self)
+            case 2: signing_algorithm = try protoReader.decode(SignedData.Algorithm.self)
+            case 3: data = try protoReader.decode(Foundation.Data.self)
+            default: try protoReader.readUnknownField(tag: tag)
             }
         }
-        self.unknownFields = try reader.endMessage(token: token)
+        self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.version = version
+        self._version.wrappedValue = version
         self.signing_algorithm = signing_algorithm
-        self.data = data
+        self._data.wrappedValue = data
     }
 
-    public func encode(to writer: ProtoWriter) throws {
-        try writer.encode(tag: 1, value: self.version)
-        try writer.encode(tag: 2, value: self.signing_algorithm)
-        try writer.encode(tag: 3, value: self.data)
-        try writer.writeUnknownFields(unknownFields)
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try protoWriter.encode(tag: 1, value: self.version)
+        try protoWriter.encode(tag: 2, value: self.signing_algorithm)
+        try protoWriter.encode(tag: 3, value: self.data)
+        try protoWriter.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension SignedData.EnvelopedData : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.version = try container.decodeIfPresent(UInt32.self, forKey: "version")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self._version.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, forKey: "version")
         self.signing_algorithm = try container.decodeIfPresent(SignedData.Algorithm.self, firstOfKeys: "signingAlgorithm", "signing_algorithm")
-        self.data = try container.decodeIfPresent(stringEncoded: Data.self, forKey: "data")
+        self._data.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, forKey: "data")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
 
         try container.encodeIfPresent(self.version, forKey: "version")
         try container.encodeIfPresent(self.signing_algorithm, forKey: preferCamelCase ? "signingAlgorithm" : "signing_algorithm")
         try container.encodeIfPresent(stringEncoded: self.data, forKey: "data")
     }
-}
-#endif
 
-#if !WIRE_REMOVE_EQUATABLE
-extension SignedData : Equatable {
-}
-#endif
-
-#if !WIRE_REMOVE_HASHABLE
-extension SignedData : Hashable {
-}
-#endif
-
-#if swift(>=5.5)
-extension SignedData : Sendable {
-}
-#endif
-
-extension SignedData : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
-        return "type.googleapis.com/app.cash.trifle.api.alpha.SignedData"
-    }
-}
-
-extension SignedData : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var enveloped_data: Data? = nil
-        var signature: Data? = nil
-        var certificates: [Certificate] = []
-
-        let token = try reader.beginMessage()
-        while let tag = try reader.nextTag(token: token) {
-            switch tag {
-            case 1: enveloped_data = try reader.decode(Data.self)
-            case 2: signature = try reader.decode(Data.self)
-            case 3: try reader.decode(into: &certificates)
-            default: try reader.readUnknownField(tag: tag)
-            }
-        }
-        self.unknownFields = try reader.endMessage(token: token)
-
-        self.enveloped_data = enveloped_data
-        self.signature = signature
-        self.certificates = certificates
-    }
-
-    public func encode(to writer: ProtoWriter) throws {
-        try writer.encode(tag: 1, value: self.enveloped_data)
-        try writer.encode(tag: 2, value: self.signature)
-        try writer.encode(tag: 3, value: self.certificates)
-        try writer.writeUnknownFields(unknownFields)
-    }
-}
-
-#if !WIRE_REMOVE_CODABLE
-extension SignedData : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.enveloped_data = try container.decodeIfPresent(stringEncoded: Data.self, firstOfKeys: "envelopedData", "enveloped_data")
-        self.signature = try container.decodeIfPresent(stringEncoded: Data.self, forKey: "signature")
-        self.certificates = try container.decodeProtoArray(Certificate.self, forKey: "certificates")
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
-        let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
-        let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
-
-        try container.encodeIfPresent(stringEncoded: self.enveloped_data, forKey: preferCamelCase ? "envelopedData" : "enveloped_data")
-        try container.encodeIfPresent(stringEncoded: self.signature, forKey: "signature")
-        if includeDefaults || !self.certificates.isEmpty {
-            try container.encodeProtoArray(self.certificates, forKey: "certificates")
-        }
-    }
 }
 #endif


### PR DESCRIPTION
Part 1 of an update to get Trifle on a more current version of Wire.  The 4.9.3 release is the last to support memberwise initializers (via `WIRE_INCLUDE_MEMBERWISE_INITIALIZER`), so it's a natural stopping point to update Trifle and projects that depend on it.  The checked-in Swift code was regenerated with 4.9.3.

Part 2 will follow this one and update to Wire 5.x