### PR TITLE
Update CI to use iPhone 15

### DIFF
--- a/.github/workflows/swift_build.yml
+++ b/.github/workflows/swift_build.yml
@@ -20,7 +20,7 @@ jobs:
         shell: bash
 
       - name: Run CocoaPod tests
-        run:  xcodebuild test -workspace ios/Example/Trifle.xcworkspace -scheme Trifle-Example  -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' -configuration Debug
+        run:  xcodebuild test -workspace ios/Example/Trifle.xcworkspace -scheme Trifle-Example  -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' -configuration Debug
 
       - name: Run Swift Package Manager tests
         run: |


### PR DESCRIPTION
iPhone 14 isn't included on the GitHub Action runner.